### PR TITLE
feat(observe): wire ic situation snapshot as canonical Observe call (Phase C / C1)

### DIFF
--- a/hooks/lib-sprint.sh
+++ b/hooks/lib-sprint.sh
@@ -300,6 +300,10 @@ sprint_read_state() {
     auto_advance="${auto_advance:-true}"
     token_budget="${token_budget:-0}"
 
+    # Canonical one-shot Observe call: `ic situation snapshot --run=<id>`
+    # (runs/dispatches/queue/budget/events). It does NOT yet project the
+    # artifacts map or phase-advance history sprint_status needs, so those
+    # stay as targeted queries below — see sylveste-owjn.2.1 (C1).
     # Launch 3 independent ic queries in parallel (artifacts, events, agents, tokens)
     local _tmp_dir
     _tmp_dir=$(mktemp -d) || { echo "{}"; return 0; }

--- a/skills/using-clavain/SKILL.md
+++ b/skills/using-clavain/SKILL.md
@@ -10,7 +10,7 @@ description: Use at start of any conversation — how to find/use skills, agents
 Clavain operates on **OODARC** — Observe · Orient · Decide · Act · Reflect · Compound — at nested timescales (per-turn, per-sprint, cross-session). Run it explicitly each turn:
 
 1. **Observe** — read the actual tool results, file state, and test output. Don't act on assumptions about what happened.
-2. **Orient** — situate against the goal and recent evidence. What changed? What's anomalous? (At sprint scale, `ic situation snapshot` gives this in one call.)
+2. **Orient** — situate against the goal and recent evidence. What changed? What's anomalous? At sprint scale, `ic situation snapshot --run=<id>` is the canonical one-shot Observe→Orient call — one query for runs, dispatches, queue, budget, and recent events, instead of polling each separately.
 3. **Decide** — choose the next action; prefer the known fast path, deliberate when novel or high-stakes.
 4. **Act** — invoke the tool / make the edit / advance the phase.
 5. **Reflect** — did the outcome match expectation? On a *significant* outcome (error, recovery, surprise, novel situation) pause and debrief before continuing; on routine ones, continue and let evidence accumulate.
@@ -33,6 +33,7 @@ The compounding half (Reflect + Compound) is what makes the system get smarter a
 | Resolve review findings | `/clavain:resolve` |
 | Set up a new project | `/clavain:project-onboard` |
 | Check project health | `/clavain:clavain-doctor` or `/clavain:sprint-status` |
+| One-shot situation snapshot (Observe) | `ic situation snapshot --run=<id>` |
 | Generate roadmap/PRD | `/interpath:roadmap` or `/interpath:prd` |
 | Check doc freshness | `/interwatch:watch` |
 | Run scenario tests | `clavain-cli scenario-run <pattern>` |


### PR DESCRIPTION
## Phase C1 — wire \`ic situation snapshot\` into the host Observe surface (bead sylveste-owjn.2.1)

\`ic situation snapshot\` (intercore \`cmd/ic/situation.go\`) already existed and aggregates runs/dispatches/queue/budget/events, but was invoked by a single Go caller and named only in passing — a textbook \"wired or it doesn't exist\" gap.

### What
- **using-clavain SKILL.md**: the per-turn Orient bullet now names the real invocation form (\`ic situation snapshot --run=<id>\`) and what it returns; added a Quick Router row so it's discoverable as *the* one-shot orientation command.
- **lib-sprint.sh**: documented the canonical Observe entry point at \`sprint_status\`'s ad-hoc-query block.

### Scope decision (wire-as-is)
\`ic situation snapshot\`'s projection does **not** include the artifacts map or phase-advance history that \`sprint_status\` builds from its 4 parallel \`ic\` queries. Rather than a risky blind swap that would drop data, this PR names it as the canonical Observe call and leaves the uncovered queries in place. A follow-up could extend \`observation.Snapshot\` to make it a true superset.

### Verify
\`bash -n hooks/lib-sprint.sh\` clean. (The \`config/decomposition-calibration.yaml\` timestamp churn is autosync runtime noise — intentionally excluded from this commit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)