### PR TITLE
next-goal: look at every reachable tracker, and check the provenance claim

### DIFF
--- a/commands/next-goal.md
+++ b/commands/next-goal.md
@@ -207,6 +207,26 @@ Never emit an improvised block that reads as though it were tracker-ranked. A
 reader cannot audit the difference after the fact, which is exactly how five
 consecutive goals went out unlinted from this path.
 
+### This is checked, not merely requested
+
+`scripts/next-goal-candidates.sh` leaves a receipt at
+`~/.cache/clavain/next-goal-provenance/$CLAUDE_SESSION_ID.json` recording
+whether any tracker answered. The Stop hook reads it
+(`hooks/lib-next-goal-provenance.sh`) and compares it against what you actually
+emitted. A block that omits the degradation disclosure is taken as claiming
+tracker provenance, so it needs a receipt saying a tracker was reached.
+
+Two things follow, and the second is the one worth internalising:
+
+1. Emitting the disclosure when it applies is enforced, not trusted.
+2. **Skipping this command does not skip the check.** No run means no receipt,
+   and a Next-goal block with no receipt is flagged as improvised — which it
+   is. Writing the block from session context to save a tool call produces a
+   warning on the next turn, not a shortcut.
+
+Set `CLAVAIN_PROVENANCE_AUDIT_DISABLE=1` to silence the audit, or
+`.claude/clavain.no-goalcadence` to opt a repo out of the whole tier.
+
 ## Step 4: Emit the block
 
 Format exactly:

--- a/commands/next-goal.md
+++ b/commands/next-goal.md
@@ -27,14 +27,39 @@ lighter-weight recommendation (see Step 3) rather than omitting it.
 
 ```bash
 SCOPE="${ARGUMENTS:-}"
+
+# Bead lookup runs through a helper, not inline bash, because `bd ready`
+# resolves from $PWD and stops at the nearest git root. Sylveste's subprojects
+# are nested git repos: from interverse/tool-time bd reports "no beads database
+# found" while the monorepo root has ready work and ~/projects has more. The
+# helper walks past those boundaries, deduplicates by the database bd actually
+# resolves to, and — critically — reports an unreachable tracker as its own
+# state instead of as an empty backlog.
+CANDIDATES_HELPER=""
+for candidate in \
+    "${CLAUDE_PLUGIN_ROOT:-}/scripts/next-goal-candidates.sh" \
+    "$HOME/.codex/clavain/scripts/next-goal-candidates.sh" \
+    "$HOME/projects/Sylveste/os/Clavain/scripts/next-goal-candidates.sh"
+do
+    if [[ -f "$candidate" ]]; then
+        CANDIDATES_HELPER="$candidate"
+        break
+    fi
+done
+
+CANDIDATES_JSON=""
 LOCAL_READY_JSON="[]"
-if command -v bd &>/dev/null; then
-    if [[ -n "$SCOPE" ]]; then
-        LOCAL_READY_JSON=$(bd ready --json --limit 20 --parent "$SCOPE" 2>/dev/null) || LOCAL_READY_JSON="[]"
-    fi
-    if [[ -z "$LOCAL_READY_JSON" || "$LOCAL_READY_JSON" == "[]" ]]; then
-        LOCAL_READY_JSON=$(bd ready --json --limit 20 2>/dev/null) || LOCAL_READY_JSON="[]"
-    fi
+TRACKER_REACHABLE="false"
+LOOKUP_FAILURES="[]"
+ROADMAP_JSON='{"status":"missing"}'
+if [[ -n "$CANDIDATES_HELPER" ]]; then
+    CANDIDATES_JSON=$(bash "$CANDIDATES_HELPER" "$SCOPE" 2>/dev/null) || CANDIDATES_JSON=""
+fi
+if [[ -n "$CANDIDATES_JSON" ]] && jq -e . >/dev/null 2>&1 <<<"$CANDIDATES_JSON"; then
+    LOCAL_READY_JSON=$(jq -c '.candidates // []'      <<<"$CANDIDATES_JSON")
+    TRACKER_REACHABLE=$(jq -r '.tracker_reachable'    <<<"$CANDIDATES_JSON")
+    LOOKUP_FAILURES=$(jq -c '.lookup_failures // []'  <<<"$CANDIDATES_JSON")
+    ROADMAP_JSON=$(jq -c '.roadmap // {status:"missing"}' <<<"$CANDIDATES_JSON")
 fi
 
 # Remontoire owns canonical promotion discovery. Its helper is read-only and
@@ -74,19 +99,31 @@ defects (dormant goals, stuck closes, missing successors) are candidate
 material and MUST be surfaced ahead of new work (f-030).
 
 `bd ready` already applies blocker-aware semantics (excludes in_progress,
-blocked, deferred, hooked) — it is the right primitive, not `bd list
---ready`. If `bd` is not installed, or the current directory has no beads
-database, `LOCAL_READY_JSON` stays empty. The Remontoire projection supplies
-ready beads labeled `remontoire-promotion` from the agency's canonical
-portfolio tracker. If either source is unavailable, continue with the other;
-if both are empty, proceed to Step 3's degraded path without error.
+blocked, deferred, hooked) — it is the right primitive, not `bd list --ready`.
+The helper applies it at every bead root it can reach and tags each candidate
+with `_root` so you can tell which tracker to file against. The Remontoire
+projection separately supplies ready beads labeled `remontoire-promotion` from
+the agency's canonical portfolio tracker. If either source is unavailable,
+continue with the other.
 
-If the repo is one of several trackers relevant to the session (e.g. a
-monorepo alongside a companion plugin repo, or the workstation vs. a synced
-server), and you know of other reachable bead roots from this session's
-context, run `bd ready --json` in each and merge results before ranking.
-Don't go hunting for trackers you have no evidence of — use what's already
-in context (recent `bd` invocations, CLAUDE.md pointers, session state).
+**`TRACKER_REACHABLE` is the field that decides whether this block may be
+improvised.** An empty `LOCAL_READY_JSON` means one of two completely
+different things, and they must not be treated alike:
+
+| `candidates` | `tracker_reachable` | meaning | what to do |
+|---|---|---|---|
+| `[]` | `true` | the backlog is genuinely clear | Step 3, and say the tracker is clear |
+| `[]` | `false` | we could not look at all | Step 3, and say so — see the required wording |
+
+Until 2026-08-07 this command could not tell those apart: it ran `bd ready
+--json 2>/dev/null || LOCAL_READY_JSON="[]"`, which turned "no beads database
+found" into the same `[]` a clean tracker produces. Every improvised block then
+presented as though it had consulted the trackers. Read `LOOKUP_FAILURES` for
+the per-root reason; each entry carries `{root, reason}`.
+
+This is the code half of bead `mk-fx3`, which closed on the strength of "the
+goal-complete hook enriches from bd ready + open epics across trackers" while
+the across-trackers part shipped as advice in this paragraph.
 
 ## Step 2: Rank by leverage
 
@@ -105,24 +142,70 @@ the `bd ready --json` schema:
   signal, but the promotion **must not automatically win**: compare it with
   priority, blocker impact, `dependent_count`, risk, and session continuity.
 
+### The roadmap signal (`ROADMAP_JSON`)
+
+`docs/roadmap.json` carries `modules`, `open_beads`, and `blocked` — portfolio
+shape that `bd ready` alone does not show. Use it to break ties: a candidate in
+a module the roadmap marks blocked, or one that closes out a module already
+near-complete, outranks an isolated task of equal priority.
+
+**Rank on it only when `.roadmap.status == "fresh"`.** The four states:
+
+- `fresh` — generated within `stale_after_days` (default 7). Usable.
+- `stale` — older than that. Do **not** rank on it; mention the staleness and
+  the `age_days` if a candidate would otherwise have been justified by it.
+- `undated` — no `generated_at` field, so freshness is unknowable. Treat as
+  stale. Unknown is not healthy.
+- `missing` / `unreadable` — no roadmap at this root. Rank without it.
+
+Freshness comes from the embedded `generated_at`, never the file's mtime. On
+2026-08-07 Sylveste's roadmap.json had an mtime of 2026-07-21 and a
+`generated_at` of 2026-07-13: a rebase had touched the file without
+regenerating it, and any mtime-based check would have called a 25-day-old
+artifact eight days fresher than it was. Regeneration is
+`scripts/sync-roadmap-json.sh`, scheduled daily by the
+`com.arouth.sylveste-roadmap` LaunchAgent; a `stale` verdict therefore usually
+means that scheduler has been down, which is worth saying out loud.
+
 Rank and select the **top 2-4** candidates. Do not just take the top 2-4 by
 `bd`'s default sort — apply the leverage lens above; a `--sort hybrid` or
 `--explain` pass can help surface why something is ready if the ranking
 isn't obvious from the JSON fields alone.
 
-## Step 3: Degraded path (no bd data)
+## Step 3: Degraded path — and which degradation it is
 
-If `READY_JSON` is empty (bd unavailable, no database, or zero ready
-issues), do not fabricate bead IDs. Instead:
-- Look at what's actually in front of you this session: open TODOs
-  mentioned in conversation, a natural next phase of the epic just
-  completed, obvious follow-on work visible in the repo (failing tests,
-  stubbed functions, a CHANGELOG "Unreleased" item without a corresponding
-  bead).
-- Present 2-3 candidates in the same format, but with `/goal <free-text
-  description>` instead of a bead ID, and note plainly: "(no beads tracker
-  detected — describe scope in the /goal text, or run `bd init` to start
-  tracking here)".
+If `READY_JSON` is empty, do not fabricate bead IDs. Build candidates from what
+is actually in front of you this session: open TODOs mentioned in conversation,
+the natural next phase of the epic just completed, obvious follow-on work
+visible in the repo (failing tests, stubbed functions, a CHANGELOG "Unreleased"
+item without a corresponding bead). Present 2-3 in the same format with
+`/goal <free-text description>` instead of a bead ID.
+
+Then state which degradation produced them. This is not optional garnish — it
+is the whole reason the caller can trust or distrust the block:
+
+**`TRACKER_REACHABLE == "false"`** — the block **must** contain the literal
+string `no tracker reachable`, followed by the failing root and its reason from
+`LOOKUP_FAILURES`. For example:
+
+```
+(no tracker reachable — /Users/sma/projects/Sylveste/interverse/tool-time:
+no beads database found. Candidates below are improvised from this session,
+not ranked from the backlog.)
+```
+
+**`TRACKER_REACHABLE == "true"` with zero candidates** — the trackers answered
+and there is genuinely nothing ready. Say that instead; it is a real and useful
+fact, not a failure:
+
+```
+(trackers reachable, nothing ready — candidates below are new work, not
+existing beads.)
+```
+
+Never emit an improvised block that reads as though it were tracker-ranked. A
+reader cannot audit the difference after the fact, which is exactly how five
+consecutive goals went out unlinted from this path.
 
 ## Step 4: Emit the block
 

--- a/hooks/auto-stop-actions.sh
+++ b/hooks/auto-stop-actions.sh
@@ -148,6 +148,23 @@ if [[ -n "$_SHADOW_SCAN_ROOT" && ! -f ".claude/clavain.no-shadow-enforce" ]]; th
     fi
 fi
 
+# Next-goal provenance audit — orthogonal to the tier waterfall, same shape as
+# the shadow-tracker scan above: computed unconditionally, consumed below.
+#
+# Cheap by construction. It reads one small receipt file that
+# scripts/next-goal-candidates.sh wrote when it ran; it never calls bd. That
+# matters here specifically — lib-shadow-tracker.sh documents this hook timing
+# out at 5s and silently dropping the entire waterfall, and the candidate
+# lookup allows 25s per bead root. Re-querying trackers from inside the hook
+# would reintroduce exactly that failure.
+PROVENANCE_WARNING=""
+if [[ ! -f ".claude/clavain.no-goalcadence" ]]; then
+    source "${SCRIPT_DIR}/lib-next-goal-provenance.sh" 2>/dev/null || true
+    if declare -F next_goal_provenance_warning >/dev/null 2>&1; then
+        PROVENANCE_WARNING="$(next_goal_provenance_warning "$SESSION_ID" "$RECENT" 2>/dev/null || true)"
+    fi
+fi
+
 # Tiered decision: goal-cadence > compound > dispatch > drift check
 # goal-completed signal: structural requirement — the completion message must
 #   END with a Next-goal block (2-4 candidates + recommendation), so this
@@ -163,12 +180,29 @@ fi
 
 REASON=""
 
+# Provenance tier: ahead of goal-cadence, because a block that already exists
+# and cannot back its claim is a more specific defect than the absence of one —
+# and its remedy (run /clavain:next-goal, re-derive the candidates) subsumes
+# what the goal-cadence tier would have asked for anyway.
+if [[ -n "$PROVENANCE_WARNING" ]]; then
+    if intercore_sentinel_check_or_legacy "next_goal_provenance_throttle" "$SESSION_ID" 300; then
+        REASON="$PROVENANCE_WARNING"
+    fi
+fi
+
 # Goal-cadence tier: fires on the goal-completed signal, ahead of every other
 # tier. Per-repo opt-out + throttle follow the same pattern as the other
 # tiers below. Fail-open: if bd/intercore are unavailable, /clavain:next-goal
 # itself degrades gracefully (see commands/next-goal.md) — this hook only
 # needs to fire the instruction, not resolve any bead data itself.
-if [[ "$SIGNALS" == *"goal-completed"* ]]; then
+#
+# The `-z "$REASON"` guard is load-bearing as of the provenance tier above:
+# this tier used to be first in the waterfall and so assigned unconditionally.
+# Left that way it would overwrite the provenance warning with the weaker
+# "please emit a block" instruction — for a block that had already been
+# emitted. The short-circuit also keeps this tier's sentinel unclaimed when
+# provenance took the cycle.
+if [[ -z "$REASON" && "$SIGNALS" == *"goal-completed"* ]]; then
     if [[ ! -f ".claude/clavain.no-goalcadence" ]]; then
         if intercore_sentinel_check_or_legacy "goal_cadence_throttle" "$SESSION_ID" 60; then
             REASON="Goal-cadence: this turn completed a /goal or goal-scale milestone. Per structural goal-cadence policy, your completion message to the user MUST end with a 'Next goal' block. Run /clavain:next-goal using the Skill tool to generate it (2-4 candidates with leverage rationale, a clear recommendation, and ready-to-paste /goal text), then append that block verbatim to the end of your reply."

--- a/hooks/lib-next-goal-provenance.sh
+++ b/hooks/lib-next-goal-provenance.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# shellcheck: sourced library — no set -euo pipefail (would alter caller's error policy)
+# lib-next-goal-provenance.sh — did that Next-goal block come from a tracker?
+# Used by: auto-stop-actions.sh (Stop hook)
+#
+# THE GAP THIS CLOSES
+#
+# scripts/next-goal-candidates.sh made "we could not look" distinguishable from
+# "nothing is there", and commands/next-goal.md requires the degraded block to
+# say `no tracker reachable`. But that requirement is prose addressed to a
+# model. The structural test only asserts the sentence still exists in the
+# command file; nothing checks that an emitted block obeys it. A model that
+# skips the command entirely and improvises candidates from session context
+# produces a block that is indistinguishable, to the reader, from one ranked
+# against 40 live beads. That is the original defect — a lookup failure wearing
+# the costume of a result — displaced one level up, from the script to the
+# prose.
+#
+# THE PREDICATE
+#
+# A block that does not disclose degradation is implicitly claiming tracker
+# provenance, so it needs a receipt to back the claim:
+#
+#   flag  <=  block present
+#             AND block does not disclose "no tracker reachable"
+#             AND NOT (receipt exists for this session AND tracker_reachable)
+#
+#   receipt reachable, no disclosure  -> ok      (healthy path)
+#   receipt unreachable, no disclosure-> FLAG    (contradicts the receipt)
+#   receipt unreachable, discloses    -> ok      (honest degradation)
+#   no receipt, no disclosure         -> FLAG    (improvised: nothing ever looked)
+#   no receipt, discloses             -> ok      (honest, even without the helper)
+#
+# The two flagged cases get DIFFERENT messages on purpose. "No receipt" and
+# "receipt says unreachable" are distinct states, and collapsing them into one
+# warning would repeat, inside the fix, the conflation the fix is about.
+#
+# DETECTING A BLOCK WITHOUT MATCHING THE INSTRUCTION THAT ASKS FOR ONE
+#
+# auto-stop-actions.sh injects a reason containing the words "Next goal block",
+# and that injection is itself written to the transcript. Matching on the
+# phrase alone would fire on the hook's own request every time it fired — the
+# hook would audit itself and always find a violation. A real block also
+# carries paste-ready /goal text, so both markers are required, and only
+# assistant lines are considered (a user pasting a /goal is not the assistant
+# claiming provenance for it).
+#
+# KNOWN GAP, STATED RATHER THAN PAPERED OVER
+#
+# When the goal-cadence tier blocks and the model answers it, that next Stop
+# arrives with stop_hook_active=true and auto-stop-actions.sh exits before
+# reaching any tier. So a block emitted in direct reply to the injection is not
+# audited in that cycle; it is audited on the next ordinary turn, if it is
+# still inside the transcript window. The self-initiated blocks — the ones the
+# global every-substantive-response rule produces with no hook prompting, and
+# so the ones most likely to be improvised — are audited immediately.
+
+[[ -n "${_LIB_NEXT_GOAL_PROVENANCE_LOADED:-}" ]] && return 0
+_LIB_NEXT_GOAL_PROVENANCE_LOADED=1
+
+CLAVAIN_PROVENANCE_DIR="${CLAVAIN_PROVENANCE_DIR:-$HOME/.cache/clavain/next-goal-provenance}"
+
+# The exact wording commands/next-goal.md requires of a degraded block. Kept as
+# a variable so the command, the helper and this hook can be checked against
+# one spelling instead of three drifting copies.
+CLAVAIN_NO_TRACKER_PHRASE="no tracker reachable"
+
+# next_goal_block_emitted <transcript_text>
+# 0 if the assistant emitted something with the shape of a Next-goal block.
+next_goal_block_emitted() {
+    local text="$1"
+    local assistant
+    assistant="$(printf '%s\n' "$text" | grep '"type":"assistant"' 2>/dev/null || true)"
+    [[ -z "$assistant" ]] && return 1
+    grep -qiE 'next[ -]goal' <<<"$assistant" 2>/dev/null || return 1
+    # Paste-ready /goal text: the marker that separates a block from a mention
+    # of one. Matches the OUTCOME: line every goal carries per goal-shape.
+    grep -q 'OUTCOME:' <<<"$assistant" 2>/dev/null || return 1
+    return 0
+}
+
+# next_goal_block_discloses_degradation <transcript_text>
+# 0 if the assistant said, in so many words, that no tracker answered.
+next_goal_block_discloses_degradation() {
+    local text="$1"
+    printf '%s\n' "$text" \
+        | grep '"type":"assistant"' 2>/dev/null \
+        | grep -qi "$CLAVAIN_NO_TRACKER_PHRASE" 2>/dev/null
+}
+
+# next_goal_receipt_path <session_id>
+next_goal_receipt_path() {
+    printf '%s/%s.json' "$CLAVAIN_PROVENANCE_DIR" "${1:-unknown}"
+}
+
+# next_goal_receipt_state <session_id>
+# Echoes one of: missing | unreadable | reachable | unreachable
+#
+# "unreadable" is deliberately NOT folded into "missing". A receipt that exists
+# but cannot be parsed means the helper ran and something went wrong writing
+# its result — a different fault from the helper never having run, and one that
+# would otherwise be invisible.
+next_goal_receipt_state() {
+    local path
+    path="$(next_goal_receipt_path "$1")"
+    [[ -f "$path" ]] || { printf 'missing\n'; return 0; }
+    command -v jq >/dev/null 2>&1 || { printf 'unreadable\n'; return 0; }
+    local reachable
+    # NOT `.tracker_reachable // "absent"`. jq's `//` treats false and null
+    # alike as empty, so the alternative form rewrote a legitimate
+    # `tracker_reachable: false` into "absent" and reported it as unreadable —
+    # silently losing the one state this audit exists to catch. `tostring`
+    # keeps false distinct from a missing key.
+    reachable="$(jq -r '.tracker_reachable | tostring' "$path" 2>/dev/null)" || {
+        printf 'unreadable\n'; return 0; }
+    case "$reachable" in
+        true)  printf 'reachable\n' ;;
+        false) printf 'unreachable\n' ;;
+        *)     printf 'unreadable\n' ;;
+    esac
+}
+
+# next_goal_receipt_detail <session_id>
+# Short human-readable summary of the receipt, for naming what vouched (or did
+# not) rather than asserting reachability without evidence.
+next_goal_receipt_detail() {
+    local path
+    path="$(next_goal_receipt_path "$1")"
+    [[ -f "$path" ]] || return 0
+    command -v jq >/dev/null 2>&1 || return 0
+    jq -r '
+        "recorded " + (.recorded_at // "at an unknown time")
+        + ", roots_ok=" + ((.roots_ok // []) | if length == 0 then "none" else join(",") end)
+        + ", failures=" + ((.lookup_failures // []) | if length == 0 then "none" else join(",") end)
+    ' "$path" 2>/dev/null || true
+}
+
+# next_goal_provenance_warning <session_id> <transcript_text>
+# Echoes a warning when a block claims provenance it does not have; silent
+# otherwise. Always exits 0 — this is a nudge, never a gate.
+next_goal_provenance_warning() {
+    local session="${1:-unknown}" text="${2:-}"
+
+    [[ "${CLAVAIN_PROVENANCE_AUDIT_DISABLE:-0}" == "1" ]] && return 0
+    next_goal_block_emitted "$text" || return 0
+    next_goal_block_discloses_degradation "$text" && return 0
+
+    local state detail
+    state="$(next_goal_receipt_state "$session")"
+    [[ "$state" == "reachable" ]] && return 0
+
+    detail="$(next_goal_receipt_detail "$session")"
+
+    case "$state" in
+        missing)
+            printf 'Next-goal provenance: this turn emitted a Next-goal block, but scripts/next-goal-candidates.sh never ran in this session — there is no receipt for %s. The candidates were therefore improvised from session context, not ranked against a tracker, and the block does not say so. Either run /clavain:next-goal and re-derive the candidates, or state in the block that the trackers were not consulted. An unchecked backlog is not an empty one.\n' "$session"
+            ;;
+        unreachable)
+            printf 'Next-goal provenance: the candidate lookup ran and reached NO tracker (%s), but the emitted block reads as tracker-ranked — it never says "%s". A block that cannot name a tracker must disclose that, per commands/next-goal.md. Add the disclosure or re-run the lookup.\n' \
+                "${detail:-no detail recorded}" "$CLAVAIN_NO_TRACKER_PHRASE"
+            ;;
+        unreadable)
+            printf 'Next-goal provenance: a receipt exists for session %s but could not be parsed, so whether any tracker answered is unknown. Unknown is not healthy — re-run /clavain:next-goal, or say in the block that provenance could not be established.\n' "$session"
+            ;;
+    esac
+    return 0
+}

--- a/scripts/next-goal-candidates.sh
+++ b/scripts/next-goal-candidates.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# Collect Next-goal candidates from every bead root reachable from this session.
+#
+# WHY THIS IS A SCRIPT AND NOT THE INLINE BASH IT REPLACES
+#
+# `bd ready` resolves from the current directory and stops at the nearest git
+# root. Sylveste's subprojects are nested git repos, so from
+# interverse/tool-time bd reports "no beads database found" while the monorepo
+# root two levels up has 30 ready issues and ~/projects has 50. The command's
+# Step 1 took that error as an empty backlog:
+#
+#     LOCAL_READY_JSON=$(bd ready --json --limit 20 2>/dev/null) || LOCAL_READY_JSON="[]"
+#
+# The 2>/dev/null swallowed the diagnostic and the || turned the failure into
+# the same "[]" that a genuinely clean tracker produces. Every block built from
+# nothing then looked exactly like a block built from a well-stocked backlog.
+#
+# bead mk-fx3 closed with "goal-complete hook enriches from bd ready + open
+# epics across trackers" — but the across-trackers half shipped as prose in the
+# command body ("if you know of other reachable bead roots... merge results"),
+# i.e. as model judgment. This file is that half as code.
+#
+# THE THREE OUTCOMES, WHICH MUST NEVER COLLAPSE INTO TWO
+#
+#   ok           root answered, candidates returned
+#   empty        root answered, nothing ready      -> a real zero
+#   unreachable  root could not be queried at all  -> NOT a zero
+#
+# `candidates: []` with `lookup_failures: []` means the backlog is genuinely
+# clear. `candidates: []` with a non-empty `lookup_failures` means we could not
+# look, and the caller must say so rather than improvising in silence.
+#
+# Read-only: never mutates a tracker, never creates a database. Fails soft —
+# an unreachable root is reported in the payload, never fatal.
+
+set -uo pipefail
+
+SCHEMA_VERSION="clavain.next-goal-candidates/v1"
+
+BD="${CLAVAIN_NEXT_GOAL_BD:-bd}"
+LIMIT="${CLAVAIN_NEXT_GOAL_LIMIT:-20}"
+PER_ROOT_TIMEOUT="${CLAVAIN_NEXT_GOAL_TIMEOUT:-25}"
+MAX_ROOTS="${CLAVAIN_NEXT_GOAL_MAX_ROOTS:-6}"
+
+# A roadmap older than this is reported as stale and NOT ranked on. Seven days
+# is chosen against the regeneration cadence, not the reading cadence: once
+# sync-roadmap-json.sh runs daily, a week of silence means the scheduler itself
+# has been down, which is the condition worth surfacing. A looser bound would
+# let a dead scheduler read as healthy — the exact failure this command is
+# being repaired for.
+ROADMAP_STALE_DAYS="${CLAVAIN_ROADMAP_STALE_DAYS:-7}"
+
+SCOPE="${1:-}"
+[[ "$SCOPE" == --* ]] && SCOPE=""
+
+die_json() {
+    printf '{"schema_version":"%s","available":false,"reason":%s,"roots":[],"candidates":[],"lookup_failures":[%s],"roadmap":{"status":"unknown"}}\n' \
+        "$SCHEMA_VERSION" "$1" "$1"
+    exit 0
+}
+
+command -v jq >/dev/null 2>&1 || die_json '"jq not installed"'
+
+# ---------------------------------------------------------------- root discovery
+
+discover_roots() {
+    if [[ -n "${CLAVAIN_NEXT_GOAL_ROOTS:-}" ]]; then
+        printf '%s\n' "${CLAVAIN_NEXT_GOAL_ROOTS}" | tr ':' '\n'
+        return
+    fi
+
+    # Walk up crossing nested-git boundaries deliberately. That crossing IS the
+    # fix: bd stops at the first git root, which is why a subproject checkout
+    # sees no tracker at all.
+    local dir="$PWD" depth=0
+    while [[ -n "$dir" && "$dir" != "/" && $depth -lt 12 ]]; do
+        [[ -d "$dir/.beads" ]] && printf '%s\n' "$dir"
+        dir="$(dirname "$dir")"
+        depth=$((depth + 1))
+    done
+
+    # The workspace tracker holds cross-project work (mk-* beads) and is not an
+    # ancestor of every checkout, so walking up does not always reach it.
+    [[ -d "$HOME/projects/.beads" ]] && printf '%s\n' "$HOME/projects"
+}
+
+mapfile -t ROOTS < <(discover_roots | awk 'NF && !seen[$0]++' | head -n "$MAX_ROOTS")
+
+# ---------------------------------------------------------------- roadmap state
+
+roadmap_state() {
+    local root="$1"
+    local slug cache_dir repo_copy cache_copy
+    slug="$(basename "$root" | tr '[:upper:]' '[:lower:]')"
+    cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/clavain"
+    repo_copy="$root/docs/roadmap.json"
+    cache_copy="${CLAVAIN_ROADMAP_CACHE:-$cache_dir/$slug-roadmap.json}"
+
+    [[ -r "$repo_copy" || -r "$cache_copy" ]] || { echo 'null'; return; }
+
+    # Two copies, deliberately. The repo copy is a committed snapshot; the cache
+    # copy is what the scheduler regenerates. Regenerating in place was
+    # rejected: docs/roadmap.json and docs/backlog.md are tracked, a single
+    # regeneration produces an ~8,000-line diff, and Sylveste's main is
+    # protected — so a daily in-repo job would dirty the tree every morning for
+    # changes nobody can land without a PR. Whichever copy carries the newer
+    # generated_at wins, and the payload names which one it was.
+    ROADMAP_REPO="$repo_copy" ROADMAP_CACHE="$cache_copy" ROADMAP_STALE_DAYS="$ROADMAP_STALE_DAYS" \
+    python3 - <<'PY' 2>/dev/null || echo 'null'
+import json, os, sys
+from datetime import datetime, timezone
+
+limit = int(os.environ["ROADMAP_STALE_DAYS"])
+now = datetime.now(timezone.utc)
+
+
+def parse(stamp):
+    if not isinstance(stamp, str) or not stamp:
+        return None
+    try:
+        when = datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return when if when.tzinfo else when.replace(tzinfo=timezone.utc)
+
+
+def load(path, source):
+    if not path or not os.access(path, os.R_OK):
+        return None
+    try:
+        with open(path) as fh:
+            doc = json.load(fh)
+    except Exception as exc:
+        return {"status": "unreadable", "path": path, "source": source,
+                "reason": str(exc)[:200], "_when": None}
+    stamp = doc.get("generated_at")
+    when = parse(stamp)
+    if when is None:
+        # No usable provenance stamp means freshness is unknowable. That is its
+        # own state, never "fresh" — reporting unknown as healthy is the bug
+        # this whole helper exists to stop.
+        out = {"status": "undated", "path": path, "source": source, "_when": None}
+        if stamp:
+            out["generated_at"] = stamp
+        return out
+    age = (now - when).total_seconds() / 86400.0
+    return {
+        "status": "stale" if age > limit else "fresh",
+        "path": path,
+        "source": source,
+        "generated_at": stamp,
+        "age_days": round(age, 1),
+        "stale_after_days": limit,
+        "open_beads": doc.get("open_beads"),
+        "blocked": doc.get("blocked"),
+        "module_count": doc.get("module_count"),
+        "_when": when,
+    }
+
+
+candidates = [c for c in (load(os.environ.get("ROADMAP_CACHE"), "cache"),
+                          load(os.environ.get("ROADMAP_REPO"), "repo")) if c]
+if not candidates:
+    print("null")
+    sys.exit(0)
+
+dated = [c for c in candidates if c["_when"] is not None]
+best = max(dated, key=lambda c: c["_when"]) if dated else candidates[0]
+best.pop("_when", None)
+json.dump(best, sys.stdout)
+PY
+}
+
+# ---------------------------------------------------------------- tracker query
+
+ROOT_REPORTS=()
+CANDIDATE_SETS=()
+FAILURES=()
+ROADMAP_JSON='null'
+SEEN_DATABASES=()
+
+# Deduplicate by the database bd actually resolves to, not by the directory we
+# found a .beads/ in. /Users/sma/projects has a .beads/ directory but bd
+# resolves past it to /Users/sma/.beads (prefix mk), so walking up from a
+# Sylveste subproject yields three directories over two real trackers. Keying
+# on the path would report a breadth of coverage that does not exist.
+resolve_tracker() {
+    local dir="$1"
+    (cd "$dir" && timeout "$PER_ROOT_TIMEOUT" "$BD" where 2>/dev/null) | awk '
+        NR == 1 { beads = $0 }
+        /^[[:space:]]*prefix:/   { prefix = $2 }
+        /^[[:space:]]*database:/ { db = $2 }
+        END { if (beads != "") printf "%s\t%s\t%s\n", beads, prefix, db }
+    '
+}
+
+for root in "${ROOTS[@]}"; do
+    [[ -d "$root" ]] || continue
+
+    if [[ "$ROADMAP_JSON" == "null" ]]; then
+        candidate_roadmap="$(roadmap_state "$root")"
+        [[ "$candidate_roadmap" != "null" ]] && ROADMAP_JSON="$candidate_roadmap"
+    fi
+
+    IFS=$'\t' read -r beads_dir prefix database < <(resolve_tracker "$root")
+    dedupe_key="${database:-${beads_dir:-$root}}"
+    if [[ -n "${dedupe_key}" ]]; then
+        already=0
+        for seen in "${SEEN_DATABASES[@]+"${SEEN_DATABASES[@]}"}"; do
+            [[ "$seen" == "$dedupe_key" ]] && already=1 && break
+        done
+        (( already )) && continue
+        SEEN_DATABASES+=("$dedupe_key")
+    fi
+
+    errfile="$(mktemp)"
+    if [[ -n "$SCOPE" ]]; then
+        out="$(cd "$root" && timeout "$PER_ROOT_TIMEOUT" "$BD" ready --json --limit "$LIMIT" --parent "$SCOPE" 2>"$errfile")"
+        rc=$?
+        if (( rc != 0 )) || [[ -z "$out" || "$out" == "[]" ]]; then
+            out="$(cd "$root" && timeout "$PER_ROOT_TIMEOUT" "$BD" ready --json --limit "$LIMIT" 2>"$errfile")"
+            rc=$?
+        fi
+    else
+        out="$(cd "$root" && timeout "$PER_ROOT_TIMEOUT" "$BD" ready --json --limit "$LIMIT" 2>"$errfile")"
+        rc=$?
+    fi
+    reason="$(head -c 300 "$errfile" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/ $//')"
+    rm -f "$errfile"
+
+    if (( rc == 124 )); then
+        status="unreachable"; reason="${reason:-timed out after ${PER_ROOT_TIMEOUT}s}"
+    elif (( rc != 0 )); then
+        status="unreachable"; reason="${reason:-bd exited $rc}"
+    elif ! jq -e . >/dev/null 2>&1 <<<"${out:-}"; then
+        # bd exited 0 but produced something that is not JSON. Treating that as
+        # an empty backlog is the same conflation this file exists to prevent.
+        status="unreachable"; reason="${reason:-bd returned unparseable output}"
+    else
+        count="$(jq 'length' <<<"$out")"
+        status="ok"; reason=""
+        (( count == 0 )) && status="empty"
+        CANDIDATE_SETS+=("$(jq -c --arg root "$root" 'map(. + {_root: $root})' <<<"$out")")
+    fi
+
+    if [[ "$status" == "unreachable" ]]; then
+        FAILURES+=("$(jq -cn --arg root "$root" --arg reason "$reason" '{root: $root, reason: $reason}')")
+    fi
+
+    ROOT_REPORTS+=("$(jq -cn \
+        --arg root "$root" \
+        --arg prefix "${prefix:-}" \
+        --arg database "${database:-}" \
+        --arg status "$status" \
+        --arg reason "$reason" \
+        --argjson ready "$( [[ "$status" == "ok" || "$status" == "empty" ]] && jq 'length' <<<"$out" || echo 0 )" \
+        '{root: $root, status: $status, ready: $ready}
+         + (if $prefix   == "" then {} else {prefix: $prefix}     end)
+         + (if $database == "" then {} else {database: $database} end)
+         + (if $reason   == "" then {} else {reason: $reason}     end)')")
+done
+
+# ---------------------------------------------------------------- assemble
+
+join_array() {
+    local IFS=,
+    printf '[%s]' "$*"
+}
+
+ROOTS_JSON="$(join_array "${ROOT_REPORTS[@]+"${ROOT_REPORTS[@]}"}")"
+FAILURES_JSON="$(join_array "${FAILURES[@]+"${FAILURES[@]}"}")"
+CANDIDATES_JSON="$(join_array "${CANDIDATE_SETS[@]+"${CANDIDATE_SETS[@]}"}")"
+CANDIDATES_JSON="$(jq -c 'add // [] | unique_by(.id)' <<<"$CANDIDATES_JSON" 2>/dev/null || echo '[]')"
+
+jq -cn \
+    --arg schema "$SCHEMA_VERSION" \
+    --argjson roots "$ROOTS_JSON" \
+    --argjson candidates "$CANDIDATES_JSON" \
+    --argjson failures "$FAILURES_JSON" \
+    --argjson roadmap "$ROADMAP_JSON" \
+    '{
+       schema_version: $schema,
+       available: true,
+       roots: $roots,
+       candidates: $candidates,
+       lookup_failures: $failures,
+       roadmap: (if $roadmap == null then {status: "missing"} else $roadmap end),
+       tracker_reachable: ([$roots[] | select(.status == "ok" or .status == "empty")] | length > 0)
+     }'

--- a/scripts/next-goal-candidates.sh
+++ b/scripts/next-goal-candidates.sh
@@ -53,7 +53,55 @@ ROADMAP_STALE_DAYS="${CLAVAIN_ROADMAP_STALE_DAYS:-7}"
 SCOPE="${1:-}"
 [[ "$SCOPE" == --* ]] && SCOPE=""
 
+# ------------------------------------------------------------------ provenance
+#
+# Every run leaves a receipt saying whether a tracker actually answered. The
+# Stop hook reads it to tell a tracker-ranked Next-goal block from an
+# improvised one (hooks/lib-next-goal-provenance.sh).
+#
+# WHY A RECEIPT AND NOT A LIVE RE-QUERY: the Stop hook is capped at 5s, and
+# lib-shadow-tracker.sh already documents what happens when a hook overruns it
+# — the whole waterfall is silently dropped. Each root here gets up to 25s of
+# bd, so re-querying from the hook would blow the cap on the first root.
+#
+# The receipt is keyed by session because the useful question is "did the
+# helper run for THIS conversation" — a stale receipt from yesterday must not
+# vouch for today's block. An ABSENT receipt is the load-bearing case: a block
+# emitted without ever running this script has no tracker provenance by
+# construction, which is exactly the state that needs flagging.
+PROVENANCE_SCHEMA="clavain.next-goal-provenance/v1"
+PROVENANCE_DIR="${CLAVAIN_PROVENANCE_DIR:-$HOME/.cache/clavain/next-goal-provenance}"
+PROVENANCE_SESSION="${CLAUDE_SESSION_ID:-unknown}"
+
+record_provenance() {
+    # $1 = tracker_reachable (true|false), $2 = compact JSON object of extras
+    local reachable="$1" extras="${2:-\{\}}"
+    [[ "${CLAVAIN_PROVENANCE_DISABLE:-0}" == "1" ]] && return 0
+    mkdir -p "$PROVENANCE_DIR" 2>/dev/null || return 0
+    local stamp
+    stamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    # Written via a temp file + mv so a hook reading concurrently never sees a
+    # half-written object and mistakes it for a malformed receipt.
+    local tmp="${PROVENANCE_DIR}/.${PROVENANCE_SESSION}.$$.tmp"
+    if command -v jq >/dev/null 2>&1; then
+        jq -cn --arg schema "$PROVENANCE_SCHEMA" --arg session "$PROVENANCE_SESSION" \
+               --arg stamp "$stamp" --argjson reachable "$reachable" --argjson extras "$extras" \
+            '{schema_version: $schema, session_id: $session, recorded_at: $stamp,
+              tracker_reachable: $reachable} + $extras' >"$tmp" 2>/dev/null || return 0
+    else
+        printf '{"schema_version":"%s","session_id":"%s","recorded_at":"%s","tracker_reachable":%s}\n' \
+            "$PROVENANCE_SCHEMA" "$PROVENANCE_SESSION" "$stamp" "$reachable" >"$tmp" 2>/dev/null || return 0
+    fi
+    mv -f "$tmp" "${PROVENANCE_DIR}/${PROVENANCE_SESSION}.json" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+    return 0
+}
+
 die_json() {
+    # A run that dies here looked at nothing, so the receipt says so. Without
+    # this the two failure modes diverge: the payload would report
+    # available:false while the hook, seeing no receipt at all, could not tell
+    # a crashed helper from a helper that was never invoked.
+    record_provenance false "$(printf '{"reason":%s}' "$1")"
     printf '{"schema_version":"%s","available":false,"reason":%s,"roots":[],"candidates":[],"lookup_failures":[%s],"roadmap":{"status":"unknown"}}\n' \
         "$SCHEMA_VERSION" "$1" "$1"
     exit 0
@@ -272,7 +320,7 @@ FAILURES_JSON="$(join_array "${FAILURES[@]+"${FAILURES[@]}"}")"
 CANDIDATES_JSON="$(join_array "${CANDIDATE_SETS[@]+"${CANDIDATE_SETS[@]}"}")"
 CANDIDATES_JSON="$(jq -c 'add // [] | unique_by(.id)' <<<"$CANDIDATES_JSON" 2>/dev/null || echo '[]')"
 
-jq -cn \
+PAYLOAD="$(jq -cn \
     --arg schema "$SCHEMA_VERSION" \
     --argjson roots "$ROOTS_JSON" \
     --argjson candidates "$CANDIDATES_JSON" \
@@ -286,4 +334,19 @@ jq -cn \
        lookup_failures: $failures,
        roadmap: (if $roadmap == null then {status: "missing"} else $roadmap end),
        tracker_reachable: ([$roots[] | select(.status == "ok" or .status == "empty")] | length > 0)
-     }'
+     }')"
+
+# The receipt carries the reachable roots by prefix so the hook can say WHICH
+# tracker vouched for the block, not merely that one did. Same reason the
+# payload keeps lookup_failures: "reachable" without a name is the kind of
+# unfalsifiable claim this whole change exists to remove.
+record_provenance \
+    "$(jq -r '.tracker_reachable' <<<"$PAYLOAD")" \
+    "$(jq -c '{
+         roots_ok: [.roots[] | select(.status == "ok" or .status == "empty") | .prefix // .root],
+         lookup_failures: [.lookup_failures[] | .root],
+         candidate_count: (.candidates | length),
+         roadmap_status: (.roadmap.status // "unknown")
+       }' <<<"$PAYLOAD")"
+
+printf '%s\n' "$PAYLOAD"

--- a/tests/shell/next_goal_candidates.bats
+++ b/tests/shell/next_goal_candidates.bats
@@ -1,0 +1,261 @@
+#!/usr/bin/env bats
+#
+# next-goal-candidates.sh exists to stop one specific conflation: a bead root
+# that could not be queried must never look like a bead root with nothing
+# ready. Both produce zero candidates; only one of them is a fact about the
+# backlog. The first three tests are that distinction, held apart deliberately.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+    load test_helper
+
+    SCRIPT_UNDER_TEST="$BATS_TEST_DIRNAME/../../scripts/next-goal-candidates.sh"
+    TEST_DIR="$(mktemp -d)"
+
+    # A stub bd. `where` always resolves (the roots under test have .beads/);
+    # `ready` behaves per-root according to a marker file, so one run can mix
+    # reachable and unreachable roots the way a real session does.
+    BD_STUB="$TEST_DIR/bd"
+    cat > "$BD_STUB" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "where" ]]; then
+    echo "$PWD/.beads"
+    echo "  prefix: $(basename "$PWD")"
+    echo "  database: $(cat "$PWD/.beads/dbpath" 2>/dev/null || echo "$PWD/.beads/dolt")"
+    exit 0
+fi
+if [[ -f "$PWD/.beads/fail" ]]; then
+    cat "$PWD/.beads/fail" >&2
+    exit 1
+fi
+cat "$PWD/.beads/ready.json" 2>/dev/null || echo "[]"
+EOF
+    chmod +x "$BD_STUB"
+    export CLAVAIN_NEXT_GOAL_BD="$BD_STUB"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+# Build a root that answers with the given ready-JSON.
+make_root() {
+    local name="$1" ready="${2:-[]}"
+    mkdir -p "$TEST_DIR/$name/.beads"
+    printf '%s' "$ready" > "$TEST_DIR/$name/.beads/ready.json"
+    printf '%s' "$TEST_DIR/$name/.beads/dolt" > "$TEST_DIR/$name/.beads/dbpath"
+    echo "$TEST_DIR/$name"
+}
+
+# Build a root whose tracker cannot be queried at all.
+make_broken_root() {
+    local name="$1" message="${2:-Error: no beads database found}"
+    mkdir -p "$TEST_DIR/$name/.beads"
+    printf '%s' "$message" > "$TEST_DIR/$name/.beads/fail"
+    printf '%s' "$TEST_DIR/$name/.beads/dolt" > "$TEST_DIR/$name/.beads/dbpath"
+    echo "$TEST_DIR/$name"
+}
+
+run_helper() {
+    CLAVAIN_NEXT_GOAL_ROOTS="$1" run --separate-stderr bash "$SCRIPT_UNDER_TEST"
+    [ "$status" -eq 0 ]
+}
+
+# --------------------------------------------------------- the three-way split
+
+@test "no-database root reports unreachable, not an empty backlog" {
+    root="$(make_broken_root broken)"
+    run_helper "$root"
+
+    [ "$(jq -r '.roots[0].status' <<<"$output")" = "unreachable" ]
+    [ "$(jq -r '.tracker_reachable' <<<"$output")" = "false" ]
+    [ "$(jq '.lookup_failures | length' <<<"$output")" -eq 1 ]
+    # The reason must survive to the caller — "we could not look" is only
+    # actionable if it says which lookup failed.
+    [[ "$(jq -r '.lookup_failures[0].reason' <<<"$output")" == *"no beads database found"* ]]
+}
+
+@test "reachable root with nothing ready reports empty, and no lookup failure" {
+    root="$(make_root quiet '[]')"
+    run_helper "$root"
+
+    [ "$(jq -r '.roots[0].status' <<<"$output")" = "empty" ]
+    [ "$(jq -r '.tracker_reachable' <<<"$output")" = "true" ]
+    [ "$(jq '.lookup_failures | length' <<<"$output")" -eq 0 ]
+}
+
+@test "empty and unreachable are distinguishable despite both yielding zero candidates" {
+    broken="$(make_broken_root broken)"
+    quiet="$(make_root quiet '[]')"
+
+    run_helper "$broken"
+    broken_out="$output"
+    run_helper "$quiet"
+    quiet_out="$output"
+
+    # Identical on the surface the old inline bash looked at...
+    [ "$(jq '.candidates | length' <<<"$broken_out")" -eq 0 ]
+    [ "$(jq '.candidates | length' <<<"$quiet_out")" -eq 0 ]
+    # ...and different on the axis that decides whether the block may be
+    # improvised in silence.
+    [ "$(jq -r '.tracker_reachable' <<<"$broken_out")" != "$(jq -r '.tracker_reachable' <<<"$quiet_out")" ]
+}
+
+# --------------------------------------------------------------- multi-root
+
+@test "candidates merge across multiple reachable roots" {
+    a="$(make_root alpha '[{"id":"alpha-1","title":"A"},{"id":"alpha-2","title":"B"}]')"
+    b="$(make_root beta  '[{"id":"beta-1","title":"C"}]')"
+    run_helper "$a:$b"
+
+    [ "$(jq '.roots | length' <<<"$output")" -eq 2 ]
+    [ "$(jq '.candidates | length' <<<"$output")" -eq 3 ]
+    # Provenance must ride along: a merged list is unusable if you cannot tell
+    # which tracker to file against.
+    [ "$(jq -r '[.candidates[]._root] | unique | length' <<<"$output")" -eq 2 ]
+}
+
+@test "a partial outage still yields the roots that answered, and still reports the one that did not" {
+    good="$(make_root alpha '[{"id":"alpha-1","title":"A"}]')"
+    bad="$(make_broken_root beta)"
+    run_helper "$good:$bad"
+
+    [ "$(jq '.candidates | length' <<<"$output")" -eq 1 ]
+    [ "$(jq '.lookup_failures | length' <<<"$output")" -eq 1 ]
+    # One healthy root is enough to make the block tracker-backed, but the
+    # failure must not vanish just because something else answered.
+    [ "$(jq -r '.tracker_reachable' <<<"$output")" = "true" ]
+}
+
+@test "roots resolving to the same database are counted once" {
+    a="$(make_root alpha '[{"id":"shared-1","title":"A"}]')"
+    b="$(make_root beta  '[{"id":"shared-1","title":"A"}]')"
+    # Both directories resolve to one tracker — the real shape of
+    # ~/projects and ~/, which bd resolves to the same mk database.
+    printf '%s' "$TEST_DIR/shared/.beads/dolt" > "$a/.beads/dbpath"
+    printf '%s' "$TEST_DIR/shared/.beads/dolt" > "$b/.beads/dbpath"
+    run_helper "$a:$b"
+
+    [ "$(jq '.roots | length' <<<"$output")" -eq 1 ]
+    [ "$(jq '.candidates | length' <<<"$output")" -eq 1 ]
+}
+
+@test "bd exiting zero with unparseable output is unreachable, not empty" {
+    mkdir -p "$TEST_DIR/garbled/.beads"
+    printf '%s' "$TEST_DIR/garbled/.beads/dolt" > "$TEST_DIR/garbled/.beads/dbpath"
+    printf 'not json at all' > "$TEST_DIR/garbled/.beads/ready.json"
+    run_helper "$TEST_DIR/garbled"
+
+    [ "$(jq -r '.roots[0].status' <<<"$output")" = "unreachable" ]
+    [ "$(jq -r '.tracker_reachable' <<<"$output")" = "false" ]
+}
+
+# ----------------------------------------------------------------- roadmap
+
+@test "roadmap freshness is judged on generated_at, not mtime" {
+    root="$(make_root alpha '[]')"
+    mkdir -p "$root/docs"
+    # Content generated 25 days ago; file touched just now. This is the exact
+    # shape of Sylveste's roadmap.json on 2026-08-07 (mtime 07-21,
+    # generated_at 07-13), which any mtime-based check calls fresh.
+    old="$(python3 -c "
+from datetime import datetime, timedelta, timezone
+print((datetime.now(timezone.utc) - timedelta(days=25)).strftime('%Y-%m-%dT%H:%M:%SZ'))")"
+    jq -n --arg t "$old" '{generated_at: $t, open_beads: 62, module_count: 85}' > "$root/docs/roadmap.json"
+    touch "$root/docs/roadmap.json"
+
+    run_helper "$root"
+    [ "$(jq -r '.roadmap.status' <<<"$output")" = "stale" ]
+    [ "$(jq -r '.roadmap.age_days >= 24' <<<"$output")" = "true" ]
+}
+
+@test "a recently generated roadmap reads fresh" {
+    root="$(make_root alpha '[]')"
+    mkdir -p "$root/docs"
+    now="$(python3 -c "
+from datetime import datetime, timezone
+print(datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))")"
+    jq -n --arg t "$now" '{generated_at: $t, open_beads: 3}' > "$root/docs/roadmap.json"
+
+    run_helper "$root"
+    [ "$(jq -r '.roadmap.status' <<<"$output")" = "fresh" ]
+}
+
+@test "a roadmap with no generated_at is undated, never fresh" {
+    root="$(make_root alpha '[]')"
+    mkdir -p "$root/docs"
+    jq -n '{open_beads: 3}' > "$root/docs/roadmap.json"
+
+    run_helper "$root"
+    # Unknown freshness is its own state. Defaulting it to fresh would be the
+    # same "unmeasured reads as healthy" bug one layer down.
+    [ "$(jq -r '.roadmap.status' <<<"$output")" = "undated" ]
+}
+
+@test "a missing roadmap is reported as missing" {
+    root="$(make_root alpha '[]')"
+    run_helper "$root"
+    [ "$(jq -r '.roadmap.status' <<<"$output")" = "missing" ]
+}
+
+@test "the stale threshold is configurable and bounds the verdict" {
+    root="$(make_root alpha '[]')"
+    mkdir -p "$root/docs"
+    old="$(python3 -c "
+from datetime import datetime, timedelta, timezone
+print((datetime.now(timezone.utc) - timedelta(days=10)).strftime('%Y-%m-%dT%H:%M:%SZ'))")"
+    jq -n --arg t "$old" '{generated_at: $t}' > "$root/docs/roadmap.json"
+
+    CLAVAIN_ROADMAP_STALE_DAYS=30 run_helper "$root"
+    [ "$(jq -r '.roadmap.status' <<<"$output")" = "fresh" ]
+
+    CLAVAIN_ROADMAP_STALE_DAYS=7 run_helper "$root"
+    [ "$(jq -r '.roadmap.status' <<<"$output")" = "stale" ]
+}
+
+@test "the newer of the cache and repo roadmap copies wins, and names its source" {
+    root="$(make_root alpha '[]')"
+    mkdir -p "$root/docs"
+    stamp() { python3 -c "
+from datetime import datetime, timedelta, timezone
+import sys
+print((datetime.now(timezone.utc) - timedelta(days=int(sys.argv[1]))).strftime('%Y-%m-%dT%H:%M:%SZ'))" "$1"; }
+
+    # Repo copy is the committed snapshot and goes stale between deliberate
+    # regenerations; the cache copy is what the scheduler maintains.
+    jq -n --arg t "$(stamp 25)" '{generated_at: $t, open_beads: 62}'  > "$root/docs/roadmap.json"
+    jq -n --arg t "$(stamp 0)"  '{generated_at: $t, open_beads: 481}' > "$TEST_DIR/cached.json"
+
+    CLAVAIN_ROADMAP_CACHE="$TEST_DIR/cached.json" run_helper "$root"
+    [ "$(jq -r '.roadmap.source' <<<"$output")" = "cache" ]
+    [ "$(jq -r '.roadmap.status' <<<"$output")" = "fresh" ]
+    [ "$(jq -r '.roadmap.open_beads' <<<"$output")" = "481" ]
+
+    # ...and the preference is by generated_at, not by which file is the cache:
+    # a stale cache must not shadow a freshly committed repo copy.
+    jq -n --arg t "$(stamp 40)" '{generated_at: $t, open_beads: 9}' > "$TEST_DIR/cached.json"
+    jq -n --arg t "$(stamp 1)"  '{generated_at: $t, open_beads: 77}' > "$root/docs/roadmap.json"
+    CLAVAIN_ROADMAP_CACHE="$TEST_DIR/cached.json" run_helper "$root"
+    [ "$(jq -r '.roadmap.source' <<<"$output")" = "repo" ]
+    [ "$(jq -r '.roadmap.open_beads' <<<"$output")" = "77" ]
+}
+
+@test "a cache copy alone is enough when the repo has no roadmap" {
+    root="$(make_root alpha '[]')"
+    now="$(python3 -c "
+from datetime import datetime, timezone
+print(datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))")"
+    jq -n --arg t "$now" '{generated_at: $t, open_beads: 5}' > "$TEST_DIR/cached.json"
+
+    CLAVAIN_ROADMAP_CACHE="$TEST_DIR/cached.json" run_helper "$root"
+    [ "$(jq -r '.roadmap.source' <<<"$output")" = "cache" ]
+    [ "$(jq -r '.roadmap.status' <<<"$output")" = "fresh" ]
+}
+
+@test "output is well-formed JSON carrying its schema version" {
+    root="$(make_root alpha '[{"id":"alpha-1","title":"A"}]')"
+    run_helper "$root"
+    [ "$(jq -r '.schema_version' <<<"$output")" = "clavain.next-goal-candidates/v1" ]
+    [ "$(jq -r '.available' <<<"$output")" = "true" ]
+}

--- a/tests/shell/next_goal_provenance.bats
+++ b/tests/shell/next_goal_provenance.bats
@@ -1,0 +1,266 @@
+#!/usr/bin/env bats
+# Tests for hooks/lib-next-goal-provenance.sh
+#
+# The predicate under test: a Next-goal block that does not disclose
+# degradation is implicitly claiming tracker provenance, and needs a receipt
+# from scripts/next-goal-candidates.sh to back that claim.
+
+setup() {
+    load test_helper
+    CACHE_DIR="$(mktemp -d)"
+    export CLAVAIN_PROVENANCE_DIR="$CACHE_DIR"
+    source "$HOOKS_DIR/lib-next-goal-provenance.sh"
+    # Re-point after sourcing: the library defaults the variable at load time.
+    CLAVAIN_PROVENANCE_DIR="$CACHE_DIR"
+}
+
+teardown() {
+    rm -rf "$CACHE_DIR"
+}
+
+# ------------------------------------------------------------------ fixtures
+
+# A transcript line as Claude Code writes it: assistant text inside a JSON
+# string, so the words are intact but newlines are escaped.
+assistant_line() {
+    printf '{"type":"assistant","message":{"content":[{"type":"text","text":"%s"}]}}\n' "$1"
+}
+
+user_line() {
+    printf '{"type":"user","message":{"content":"%s"}}\n' "$1"
+}
+
+# A block that reads as tracker-ranked: names a Next goal, carries paste-ready
+# /goal text, says nothing about degradation.
+block_claiming_provenance() {
+    assistant_line "## Next goal\\n\\n1. Close mk-i43y\\n\\n/goal Ship it.\\n\\nOUTCOME: the thing is live. Stop after 5 turns."
+}
+
+block_disclosing_degradation() {
+    assistant_line "## Next goal\\n\\nno tracker reachable — the sylveste root did not answer, so these are improvised.\\n\\n/goal Ship it.\\n\\nOUTCOME: the thing is live. Stop after 5 turns."
+}
+
+write_receipt() {
+    # $1 = tracker_reachable literal (true|false)
+    cat > "$CLAVAIN_PROVENANCE_DIR/sess-1.json" <<EOF
+{"schema_version":"clavain.next-goal-provenance/v1","session_id":"sess-1",
+ "recorded_at":"2026-08-07T12:00:00Z","tracker_reachable":$1,
+ "roots_ok":["sylveste","mk"],"lookup_failures":[],"candidate_count":40,
+ "roadmap_status":"fresh"}
+EOF
+}
+
+# ------------------------------------------------- the flagged cases (the point)
+
+@test "flags a block that claims provenance when the helper never ran" {
+    run next_goal_provenance_warning "sess-1" "$(block_claiming_provenance)"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"never ran in this session"* ]]
+}
+
+@test "flags a block that reads as tracker-ranked when no tracker was reached" {
+    write_receipt false
+    run next_goal_provenance_warning "sess-1" "$(block_claiming_provenance)"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"reached NO tracker"* ]]
+    [[ "$output" == *"no tracker reachable"* ]]
+}
+
+@test "the two failure modes get distinguishable messages" {
+    run next_goal_provenance_warning "sess-1" "$(block_claiming_provenance)"
+    missing_msg="$output"
+    write_receipt false
+    run next_goal_provenance_warning "sess-1" "$(block_claiming_provenance)"
+    unreachable_msg="$output"
+    [ -n "$missing_msg" ]
+    [ -n "$unreachable_msg" ]
+    [ "$missing_msg" != "$unreachable_msg" ]
+}
+
+@test "flags a receipt that exists but cannot be parsed" {
+    printf 'not json at all\n' > "$CLAVAIN_PROVENANCE_DIR/sess-1.json"
+    run next_goal_provenance_warning "sess-1" "$(block_claiming_provenance)"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"could not be parsed"* ]]
+}
+
+@test "a receipt missing the tracker_reachable key is unreadable, not reachable" {
+    printf '{"schema_version":"x","session_id":"sess-1"}\n' > "$CLAVAIN_PROVENANCE_DIR/sess-1.json"
+    run next_goal_receipt_state "sess-1"
+    [ "$output" = "unreadable" ]
+}
+
+# ------------------------------------------------------------- the silent cases
+
+@test "silent when a receipt vouches for the block" {
+    write_receipt true
+    run next_goal_provenance_warning "sess-1" "$(block_claiming_provenance)"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent when the block honestly discloses degradation" {
+    write_receipt false
+    run next_goal_provenance_warning "sess-1" "$(block_disclosing_degradation)"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent when no Next-goal block was emitted at all" {
+    run next_goal_provenance_warning "sess-1" "$(assistant_line "Just an ordinary reply with no block.")"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent on an empty transcript" {
+    run next_goal_provenance_warning "sess-1" ""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "receipts are per session: another session's receipt does not vouch" {
+    write_receipt true   # written for sess-1
+    run next_goal_provenance_warning "sess-2" "$(block_claiming_provenance)"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"never ran in this session"* ]]
+}
+
+# --------------------------------------------- detection must not self-trigger
+
+@test "the goal-cadence instruction is not itself mistaken for a block" {
+    # auto-stop-actions.sh injects this text, and the injection lands in the
+    # transcript. Matching on the phrase alone would make the hook audit its
+    # own request and always find a violation.
+    injected=$(assistant_line "Goal-cadence: your completion message to the user MUST end with a Next goal block. Run /clavain:next-goal to generate it.")
+    run next_goal_provenance_warning "sess-1" "$injected"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "a user pasting a /goal is not the assistant claiming provenance" {
+    pasted=$(user_line "/goal Ship the thing. OUTCOME: it is live. Next goal after that.")
+    run next_goal_provenance_warning "sess-1" "$pasted"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "a Next-goal mention without paste-ready goal text is not a block" {
+    run next_goal_provenance_warning "sess-1" \
+        "$(assistant_line "I will add a Next goal block at the end of the next reply.")"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------- escape hatch
+
+@test "audit can be disabled outright" {
+    CLAVAIN_PROVENANCE_AUDIT_DISABLE=1 run next_goal_provenance_warning \
+        "sess-1" "$(block_claiming_provenance)"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "receipt state is missing when the cache dir does not exist" {
+    CLAVAIN_PROVENANCE_DIR="$CACHE_DIR/nope"
+    run next_goal_receipt_state "sess-1"
+    [ "$output" = "missing" ]
+}
+
+# ------------------------------------------------- helper writes what hook reads
+#
+# The contract has two ends. Above asserts the hook reads a receipt correctly;
+# this asserts the helper actually produces one in that shape, so the two
+# cannot drift apart silently.
+
+@test "the helper writes a receipt the hook can read" {
+    stub_dir="$(mktemp -d)"
+    cat > "$stub_dir/bd" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "where" ]]; then
+    echo "$PWD/.beads"; echo "  prefix: tst"; echo "  database: $PWD/.beads/tst.db"; exit 0
+fi
+if [[ "$1" == "ready" ]]; then echo '[{"id":"tst-1","title":"a ready bead"}]'; exit 0; fi
+exit 0
+EOF
+    chmod +x "$stub_dir/bd"
+    root="$(mktemp -d)"; mkdir -p "$root/.beads"
+
+    (
+        cd "$root" || exit 1
+        PATH="$stub_dir:$PATH" \
+        CLAUDE_SESSION_ID="sess-helper" \
+        CLAVAIN_PROVENANCE_DIR="$CACHE_DIR" \
+        CLAVAIN_NEXT_GOAL_ROOTS="$root" \
+            "$BATS_TEST_DIRNAME/../../scripts/next-goal-candidates.sh" >/dev/null
+    )
+
+    [ -f "$CACHE_DIR/sess-helper.json" ]
+    run next_goal_receipt_state "sess-helper"
+    [ "$output" = "reachable" ]
+
+    rm -rf "$stub_dir" "$root"
+}
+
+# ------------------------------------------------------- hook wiring, end to end
+#
+# The unit tests above prove the predicate. These prove auto-stop-actions.sh
+# actually reaches it. That wiring is its own risk: the provenance tier was
+# inserted ABOVE a goal-cadence tier that had assigned REASON unconditionally
+# for as long as it had been first in the waterfall.
+
+run_stop_hook() {
+    # $1 = transcript body, $2 = session id
+    local body="$1" session="$2"
+    local tmp; tmp="$(mktemp -d)"
+    printf '%s\n' "$body" > "$tmp/transcript.jsonl"
+
+    cat > "$tmp/ic" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+    health)   exit 0 ;;
+    sentinel) exit 0 ;;   # 0 = allowed, never throttled
+esac
+exit 0
+EOF
+    chmod +x "$tmp/ic"
+
+    (
+        cd "$tmp" || exit 1
+        printf '{"session_id":"%s","transcript_path":"%s","stop_hook_active":false}' \
+            "$session" "$tmp/transcript.jsonl" \
+        | PATH="$tmp:$PATH" CLAVAIN_PROVENANCE_DIR="$CLAVAIN_PROVENANCE_DIR" \
+              CLAVAIN_LOOP_BREAKER_DIR="$tmp/loop-breaker" \
+              bash "$BATS_TEST_DIRNAME/../../hooks/auto-stop-actions.sh"
+    )
+    rm -rf "$tmp"
+}
+
+@test "hook blocks with the provenance warning on an unbacked block" {
+    run run_stop_hook "$(block_claiming_provenance)" "sess-1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"decision"'* ]]
+    [[ "$output" == *"Next-goal provenance"* ]]
+}
+
+@test "hook stays quiet when a receipt vouches for the block" {
+    write_receipt true
+    run run_stop_hook "$(block_claiming_provenance)" "sess-1"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Next-goal provenance"* ]]
+}
+
+@test "provenance outranks goal-cadence rather than being overwritten by it" {
+    # Both tiers are eligible: the turn says a goal was completed AND the block
+    # it emitted cannot back its provenance. The specific complaint must win.
+    transcript="$(assistant_line "The /goal is complete and shipped.")
+$(block_claiming_provenance)"
+    # Distinct session id on purpose: lib-loop-breaker.sh (mk-ax8) goes silent
+    # when the same demand repeats for one session with no intervening
+    # progress, and the unbacked-block case above already fired this exact
+    # reason for sess-1. Reusing it would make this test pass or fail on test
+    # ordering rather than on tier precedence.
+    run run_stop_hook "$transcript" "sess-tier-order"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Next-goal provenance"* ]]
+    [[ "$output" != *"Goal-cadence:"* ]]
+}

--- a/tests/structural/test_commands.py
+++ b/tests/structural/test_commands.py
@@ -86,3 +86,52 @@ def test_next_goal_merges_remontoire_promotions_without_forcing(project_root):
     assert "unique_by(.id)" in content
     assert "must not automatically win" in content
     assert "dependent_count" in content
+
+
+def test_next_goal_reads_candidates_through_the_helper(project_root):
+    """Cross-tracker lookup is code, not an instruction to go looking.
+
+    The prose version of this ("if you know of other reachable bead roots...
+    merge results before ranking") was what bead mk-fx3 closed on, and it never
+    ran: bd resolves from $PWD and stops at the nearest git root, so from a
+    Sylveste subproject the command saw no tracker at all.
+    """
+    content = (project_root / "commands" / "next-goal.md").read_text()
+    helper = project_root / "scripts" / "next-goal-candidates.sh"
+
+    assert helper.exists(), "the cross-tracker lookup helper is missing"
+    assert helper.stat().st_mode & 0o111, "helper is not executable"
+    assert "next-goal-candidates.sh" in content
+    assert "TRACKER_REACHABLE" in content
+    # The old formulation collapsed "could not look" into "nothing there".
+    assert 'LOCAL_READY_JSON=$(bd ready --json --limit 20 2>/dev/null)' not in content
+
+
+def test_next_goal_degraded_path_names_which_degradation(project_root):
+    """An improvised block must be distinguishable from a tracker-ranked one.
+
+    Both produce candidates in the same format; only the wording tells a reader
+    whether the backlog was consulted. Without this the block is unauditable
+    after the fact, which is how it came to need double-checking.
+    """
+    content = (project_root / "commands" / "next-goal.md").read_text()
+
+    # The exact string the emitted block must carry when lookup failed.
+    assert "no tracker reachable" in content
+    # ...and the opposite case, which is a real fact rather than a failure.
+    assert "trackers reachable, nothing ready" in content
+    assert "LOOKUP_FAILURES" in content
+
+
+def test_next_goal_ranks_roadmap_only_when_fresh(project_root):
+    """A stale roadmap is withdrawn from ranking, not quietly ranked on."""
+    content = (project_root / "commands" / "next-goal.md").read_text()
+
+    assert 'roadmap.status == "fresh"' in content
+    # Freshness comes from the embedded stamp. Sylveste's roadmap.json carried
+    # an mtime eight days newer than its generated_at, so an mtime check called
+    # a 25-day-old artifact fresh.
+    assert "generated_at" in content
+    assert "mtime" in content
+    # Unknown freshness is its own state, never "fresh".
+    assert "undated" in content

--- a/tests/structural/test_commands.py
+++ b/tests/structural/test_commands.py
@@ -135,3 +135,70 @@ def test_next_goal_ranks_roadmap_only_when_fresh(project_root):
     assert "mtime" in content
     # Unknown freshness is its own state, never "fresh".
     assert "undated" in content
+
+
+def test_next_goal_provenance_audit_is_wired_into_the_stop_hook(project_root):
+    """The 'no tracker reachable' requirement is enforced, not just written down.
+
+    Every assertion above this one checks that a sentence still exists in a
+    markdown file. That guards deletion, not compliance: a model that skips
+    the command entirely satisfies all of them while emitting an improvised
+    block. The Stop hook closes that by comparing the emitted block against
+    the receipt the candidate helper leaves behind.
+    """
+    lib = project_root / "hooks" / "lib-next-goal-provenance.sh"
+    assert lib.exists(), "provenance audit library is missing"
+
+    hook = (project_root / "hooks" / "auto-stop-actions.sh").read_text()
+    assert "lib-next-goal-provenance.sh" in hook
+    assert "next_goal_provenance_warning" in hook
+
+    # The tier must sit ABOVE goal-cadence, and goal-cadence must guard on an
+    # empty REASON. It assigned unconditionally while it was first in the
+    # waterfall; left that way it silently overwrites the provenance warning
+    # with the weaker "please emit a block" instruction.
+    provenance_at = hook.index("PROVENANCE_WARNING")
+    cadence_at = hook.index('"goal-completed"')
+    assert provenance_at < cadence_at, "provenance tier must precede goal-cadence"
+    assert '-z "$REASON" && "$SIGNALS" == *"goal-completed"*' in hook
+
+
+def test_next_goal_helper_records_a_receipt(project_root):
+    """The helper must leave evidence a hook can check without re-querying bd.
+
+    Re-querying from the Stop hook is not an option: the hook is capped at 5s
+    and each bead root allows 25s of bd, so the first root alone would blow it.
+    """
+    helper = (project_root / "scripts" / "next-goal-candidates.sh").read_text()
+
+    assert "record_provenance" in helper
+    assert "clavain.next-goal-provenance/v1" in helper
+    # Keyed by session: a receipt from yesterday must not vouch for today.
+    assert "CLAUDE_SESSION_ID" in helper
+    # A crashed run records that it looked at nothing, so "helper failed" stays
+    # distinguishable from "helper was never invoked".
+    assert "record_provenance false" in helper
+
+
+def test_next_goal_provenance_keeps_absent_and_unreachable_distinct(project_root):
+    """The two ways a block can lack provenance must not collapse into one.
+
+    Collapsing them would repeat, inside the fix, the exact conflation the fix
+    exists to remove.
+    """
+    lib = (project_root / "hooks" / "lib-next-goal-provenance.sh").read_text()
+
+    for state in ("missing", "unreachable", "unreadable", "reachable"):
+        assert state in lib, f"receipt state {state!r} is not handled"
+
+    # NOT `.tracker_reachable // "absent"` — jq's `//` treats false and null
+    # alike, so the alternative form reported a legitimate "no tracker
+    # answered" receipt as unreadable and lost the state that matters most.
+    #
+    # Checked against code lines only: the library explains this trap in a
+    # comment that necessarily quotes the buggy form.
+    code = [ln for ln in lib.splitlines() if not ln.lstrip().startswith("#")]
+    assert not any(".tracker_reachable // " in ln for ln in code), (
+        "jq's // operator swallows a false tracker_reachable"
+    )
+    assert "tracker_reachable | tostring" in lib


### PR DESCRIPTION
Next-goal blocks had been needing double-checking. The cause was not the ranking logic but the lookup underneath it, and then the prose that was supposed to compensate.

## Why the blocks were wrong

`bd ready` resolves from the current directory and stops at the nearest git root. Sylveste's subprojects are nested git repos, so from `interverse/tool-time` bd reports "no beads database found" while the monorepo root has 30 ready issues and `~/projects` has 50. Step 1 ran:

```bash
LOCAL_READY_JSON=$(bd ready --json --limit 20 2>/dev/null) || LOCAL_READY_JSON="[]"
```

The `2>/dev/null` swallowed the diagnostic and the `||` turned the failure into the same `[]` a genuinely clean tracker produces. The command then improvised candidates from session context and presented them in the format used for tracker-ranked ones, with nothing marking the difference.

Bead `mk-fx3` closed on "the goal-complete hook enriches from `bd ready` + open epics across trackers", but the across-trackers half shipped as prose in the command body rather than as code.

## What lands here

**`scripts/next-goal-candidates.sh`** — walks up past nested-git boundaries; deduplicates by the database `bd` resolves to rather than by directory (`~/projects` and `~/` both hold a `.beads/` but resolve to one tracker); keeps `ok` / `empty` / `unreachable` distinct; treats bd exiting 0 with unparseable output as unreachable; judges roadmap freshness on the embedded `generated_at`, never mtime.

**`hooks/lib-next-goal-provenance.sh`** — the second commit's subject. The `no tracker reachable` requirement was prose addressed to a model, guarded only by a structural test asserting the sentence still existed in the file. That guards deletion, not compliance. The helper now leaves a session-keyed receipt recording whether any tracker answered; the Stop hook reads it and flags a block that omits the disclosure without a receipt to back the claim. Skipping the command does not skip the check — no run means no receipt, and a block with no receipt is improvised by construction.

A receipt rather than a live re-query because `lib-shadow-tracker.sh` already documents this hook timing out at 5s and silently dropping the whole waterfall, while the lookup allows 25s per bead root.

## Freshness

Sylveste's `docs/roadmap.json` carried mtime `2026-07-21` and `generated_at` `2026-07-13` — a rebase touched it without regenerating it, so any filesystem check read a 25-day-old artifact as eight days fresher. The stale copy claimed 62 open beads and 1 blocked against a live 481 and 128, so ranking on it would have been misleading rather than merely dated. Ranking uses the roadmap only when it reads fresh; a roadmap with no `generated_at` reports `undated`, never `fresh`. A companion LaunchAgent (`com.arouth.sylveste-roadmap`, in dotfiles) regenerates it daily into `~/.cache/clavain`.

## Two traps the tests found

- `.tracker_reachable // "absent"` was wrong: jq's `//` treats `false` and `null` alike as empty, so a receipt correctly reporting `tracker_reachable: false` was rewritten to `"absent"` and classified unreadable. The one value the audit exists to detect was the one value `//` swallowed.
- The goal-cadence tier assigned `REASON` unconditionally, safe only while it was first in the waterfall. It now guards on `-z "$REASON"`; without that it overwrote the specific complaint with the weaker "please emit a block" instruction, for a block already emitted.

## Verification

- Run from three directories: `interverse/tool-time` → 2 roots (`sylveste`, `mk`), 40 candidates, previously 0. Sylveste root → same. `/tmp` → 1 root (`mk`), 20 candidates.
- **bats 726 passed / 4 failed of 730.** All 4 reproduce identically on `origin/main` (2 in `test_bd_push_dolt_gate.bats`, 2 in `test_calibration_close_gate.bats`) — pre-existing and unrelated.
- **Structural 865 passed / 1 skipped**, from a 860/1 baseline. The +5 is +3 new tests in `test_commands.py` and +2 auto-parametrized over the new hook library.
- 34 new bats cases across the two suites, with empty-vs-unreachable held apart deliberately, and three driving `auto-stop-actions.sh` end to end because tier ordering is the part that would silently disable the feature.

## Known gap, stated rather than papered over

A block emitted in direct reply to the goal-cadence injection arrives with `stop_hook_active=true`, so the hook exits before any tier and that block is not audited in that cycle; it is audited on the next ordinary turn if still in the transcript window. The self-initiated blocks — the ones most likely to be improvised — are audited immediately.

Closes mk-i43y. Successor to mk-fx3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP9aw3farEUYnyizz5zwmd
