### PR TITLE
next-goal: rank on parked work, not just ready work

### DIFF
--- a/commands/next-goal.md
+++ b/commands/next-goal.md
@@ -167,6 +167,35 @@ artifact eight days fresher than it was. Regeneration is
 `com.arouth.sylveste-roadmap` LaunchAgent; a `stale` verdict therefore usually
 means that scheduler has been down, which is worth saying out loud.
 
+### The backlog signal (`.roadmap.backlog`)
+
+Same object, same freshness gate — `backlog` rides inside `roadmap`, so if
+`.roadmap.status` is not `fresh`, this is not usable either.
+
+- **`deferred_ids` / `deferred`** — work that was explicitly parked. **Never
+  propose a deferred bead as a next goal.** Deferring was a decision; putting
+  it back up for selection silently reopens it. If a candidate from `bd ready`
+  appears in `deferred_ids`, drop it and say why.
+- **`blocked_ids` / `blocked`** — real dependency edges, not merely items whose
+  own status says blocked. A blocked candidate can still be the right goal when
+  the goal is *unblocking* it, but say what it is waiting on.
+- **`module_load`** — open items per module, highest first. Use it for leverage:
+  a candidate in a module carrying most of the backlog compounds more than an
+  equal-priority task in a module with two items.
+- **`by_priority`** — P0..P4 distribution, for whether the backlog is
+  top-heavy.
+
+Derived from `roadmap.json`, not from `docs/backlog.md`. The markdown is itself
+generated from the JSON — a filtered rendering with no field the JSON lacks and
+no timestamp of its own — so parsing it would add a parser and lose precision.
+
+One caveat worth carrying: `deferred` was only ever computable after
+interpath#1. The generator had no `deferred` branch, so all 18 deferred beads
+read as ordinary open work. A roadmap generated before that fix reports
+`deferred: 0` — which is indistinguishable from a tracker with nothing parked.
+If `deferred` is 0 and the roadmap predates 2026-08-07, treat it as unknown
+rather than as a real zero.
+
 Rank and select the **top 2-4** candidates. Do not just take the top 2-4 by
 `bd`'s default sort — apply the leverage lens above; a `--sort hybrid` or
 `--explain` pass can help surface why something is ready if the ranking

--- a/scripts/next-goal-candidates.sh
+++ b/scripts/next-goal-candidates.sh
@@ -156,6 +156,7 @@ roadmap_state() {
     ROADMAP_REPO="$repo_copy" ROADMAP_CACHE="$cache_copy" ROADMAP_STALE_DAYS="$ROADMAP_STALE_DAYS" \
     python3 - <<'PY' 2>/dev/null || echo 'null'
 import json, os, sys
+from collections import Counter
 from datetime import datetime, timezone
 
 limit = int(os.environ["ROADMAP_STALE_DAYS"])
@@ -170,6 +171,54 @@ def parse(stamp):
     except ValueError:
         return None
     return when if when.tzinfo else when.replace(tzinfo=timezone.utc)
+
+
+def backlog_view(doc):
+    """The backlog signal, taken from the roadmap rather than from backlog.md.
+
+    docs/backlog.md announces itself as "generated from roadmap.json" and is a
+    filtered rendering of it: 435 markdown bullets over the same 499 items,
+    carrying no field the JSON lacks and no timestamp of its own beyond a
+    date-only "Last synced". Parsing markdown to recover data that is already
+    structured one file upstream would add a parser and lose precision, so the
+    signal is derived here and gated on the same freshness rule.
+
+    `deferred` is the load-bearing part. Deferred beads are work someone
+    explicitly parked, and proposing one as a next goal re-opens a decision
+    that was already made. Until interpath#1 the generator had no deferred
+    branch at all and all 18 of them read as ordinary open work, so this
+    signal could not have been computed correctly before that fix.
+    """
+    roadmap = doc.get("roadmap") or {}
+    items = []
+    for phase in ("now", "next", "later"):
+        for entry in (roadmap.get(phase) or []):
+            if isinstance(entry, dict) and entry.get("id"):
+                items.append(entry)
+
+    deferred, blocked, per_module, per_priority = set(), set(), Counter(), Counter()
+    for entry in items:
+        status = entry.get("status")
+        if status == "closed":
+            continue
+        if status == "deferred":
+            deferred.add(entry["id"])
+            continue
+        if status == "blocked":
+            blocked.add(entry["id"])
+        per_module[entry.get("module") or "unknown"] += 1
+        per_priority[entry.get("priority") or "unknown"] += 1
+
+    # Capped: this rides in a payload the command reads inline, and a tracker
+    # with thousands of parked items should not crowd out the candidates.
+    return {
+        "deferred": len(deferred),
+        "deferred_ids": sorted(deferred)[:200],
+        "blocked": len(blocked),
+        "blocked_ids": sorted(blocked)[:200],
+        "by_priority": dict(sorted(per_priority.items())),
+        "module_load": [{"module": m, "open": n} for m, n in per_module.most_common(8)],
+    }
 
 
 def load(path, source):
@@ -202,6 +251,7 @@ def load(path, source):
         "open_beads": doc.get("open_beads"),
         "blocked": doc.get("blocked"),
         "module_count": doc.get("module_count"),
+        "backlog": backlog_view(doc),
         "_when": when,
     }
 

--- a/tests/shell/next_goal_candidates.bats
+++ b/tests/shell/next_goal_candidates.bats
@@ -259,3 +259,71 @@ print(datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))")"
     [ "$(jq -r '.schema_version' <<<"$output")" = "clavain.next-goal-candidates/v1" ]
     [ "$(jq -r '.available' <<<"$output")" = "true" ]
 }
+
+# ------------------------------------------------------------- backlog signal
+#
+# Derived from roadmap.json, not from docs/backlog.md: the markdown is a
+# filtered rendering of the same JSON, so parsing it would add a parser and
+# lose precision. Gated on the same freshness rule, because the signal rides
+# inside the roadmap object rather than beside it.
+
+# One root whose roadmap carries a mix of statuses: open, blocked, deferred,
+# and closed. Every assertion below turns on keeping those four apart.
+make_backlog_root() {
+    local stamp="$1"
+    local root
+    root="$(make_root backlog '[]')"
+    mkdir -p "$root/docs"
+    jq -n --arg t "$stamp" '{
+      project: "demo", generated_at: $t, open_beads: 4, blocked: 1, module_count: 2,
+      roadmap: {
+        now:  [{id:"d-1",title:"a",module:"core",priority:"P1",status:"open"}],
+        next: [{id:"d-2",title:"b",module:"core",priority:"P2",status:"blocked"},
+               {id:"d-3",title:"c",module:"edge",priority:"P2",status:"open"}],
+        later:[{id:"d-4",title:"d",module:"core",priority:"P3",status:"deferred"},
+               {id:"d-5",title:"e",module:"edge",priority:"P3",status:"closed"}]
+      }}' > "$root/docs/roadmap.json"
+    echo "$root"
+}
+
+@test "backlog: deferred beads are counted and named" {
+    root="$(make_backlog_root "$(date -u +%Y-%m-%dT%H:%M:%SZ)")"
+    run_helper "$root"
+    [ "$(jq -r '.roadmap.status' <<<"$output")" = "fresh" ]
+    [ "$(jq -r '.roadmap.backlog.deferred' <<<"$output")" = "1" ]
+    [ "$(jq -r '.roadmap.backlog.deferred_ids[0]' <<<"$output")" = "d-4" ]
+}
+
+@test "backlog: a deferred bead does not inflate module load" {
+    root="$(make_backlog_root "$(date -u +%Y-%m-%dT%H:%M:%SZ)")"
+    run_helper "$root"
+    # core holds d-1 and d-2 live plus d-4 parked. Counting the parked one
+    # would make a module nobody is working make look like the busiest.
+    core="$(jq -r '.roadmap.backlog.module_load[] | select(.module=="core") | .open' <<<"$output")"
+    [ "$core" = "2" ]
+}
+
+@test "backlog: closed items are excluded from every count" {
+    root="$(make_backlog_root "$(date -u +%Y-%m-%dT%H:%M:%SZ)")"
+    run_helper "$root"
+    total="$(jq -r '[.roadmap.backlog.by_priority | to_entries[] | .value] | add' <<<"$output")"
+    [ "$total" = "3" ]
+    edge="$(jq -r '.roadmap.backlog.module_load[] | select(.module=="edge") | .open' <<<"$output")"
+    [ "$edge" = "1" ]
+}
+
+@test "backlog: blocked ids are named, not just counted" {
+    root="$(make_backlog_root "$(date -u +%Y-%m-%dT%H:%M:%SZ)")"
+    run_helper "$root"
+    [ "$(jq -r '.roadmap.backlog.blocked' <<<"$output")" = "1" ]
+    [ "$(jq -r '.roadmap.backlog.blocked_ids[0]' <<<"$output")" = "d-2" ]
+}
+
+@test "backlog: one freshness gate, shared with the roadmap" {
+    # A stale roadmap must not yield a backlog the caller treats as current.
+    # The gate is .roadmap.status — a second gate that could disagree with it
+    # would recreate the ambiguity this helper exists to remove.
+    root="$(make_backlog_root "2020-01-01T00:00:00Z")"
+    run_helper "$root"
+    [ "$(jq -r '.roadmap.status' <<<"$output")" = "stale" ]
+}


### PR DESCRIPTION
`bd ready` says what *could* be started. It does not say what was deliberately put down. Proposing a deferred bead as a next goal silently reopens a decision somebody already made, and nothing in the ranking path could tell the difference.

The roadmap payload gains a `backlog` object: **deferred and blocked ids by name** rather than by count, open items per module, and the P0–P4 distribution. The command drops any candidate appearing in `deferred_ids`, and must say what a blocked candidate is waiting on.

## Derived from roadmap.json, not docs/backlog.md

The goal asked for backlog.md. I built it from the JSON instead, and the reason is in the file itself: backlog.md announces it is *"generated from roadmap.json"*. It is a filtered rendering — **435 bullets over the same 499 items**, carrying no field the JSON lacks and no timestamp of its own beyond a date-only `Last synced`. Parsing it would add a markdown parser to recover data already structured one file upstream, and lose timestamp precision doing it. The signal is computed from the roadmap document *already parsed for freshness*, so it costs nothing extra.

## One gate, not two

`backlog` rides **inside** `roadmap` rather than beside it, so it inherits `.roadmap.status` exactly. A second freshness gate could disagree with the first — which is the ambiguity this helper exists to remove.

Deferred work is excluded from `module_load` deliberately: counting parked items would make a module nobody is working read as the busiest, inverting the leverage signal it exists to provide.

## A caveat the command carries rather than hides

`deferred` was **not computable before [interpath#1](https://github.com/mistakeknot/interpath/pull/1)**. That generator had no deferred branch, so all 18 deferred beads read as ordinary open work. A roadmap generated earlier reports `deferred: 0`, which is indistinguishable from a tracker with nothing parked. The command says to treat that as unknown, not as a zero — the same discipline as `undated` vs `fresh`.

## Verification

Against the live Sylveste roadmap: **deferred 18** (matching the tracker exactly), blocked 120, P0..P4 = 6/54/274/141/6, `module_load` led by `sylveste` at 360.

5 new bats cases (20 in the file), 19 provenance cases and **865 structural / 1 skipped** still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP9aw3farEUYnyizz5zwmd