### PR TITLE
next-goal: refuse a pick the last goal excluded; read the tracker from the main checkout

### DIFF
--- a/commands/next-goal.md
+++ b/commands/next-goal.md
@@ -217,12 +217,18 @@ do
 done
 
 # Every bead ID the block will cite, with --recommend naming the pick. Add
-# --path for anything a candidate proposes to CREATE, and --beat when the pick
-# continues the lineage of the goals just closed (both below). Exits 3 if any
-# candidate is disqualified.
+# --path for anything a candidate proposes to CREATE, --beat when the pick
+# continues the lineage of the goals just closed, and ALWAYS --text with the
+# /goal line you are about to emit plus --out-of naming where the just-closed
+# goal's condition lives (all below). Exits 3 if any candidate is disqualified.
 VERIFY_JSON=$(bash "$VERIFY_HELPER" --recommend solwend-abcd solwend-abcd mk-1234 \
+                   --text "/goal solwend-abcd — OUTCOME: ..." --out-of solwend-epic \
                    --path apps/web/components/thing/ 2>/dev/null)
 ```
+
+A free-text pick (no bead) still goes through the verifier: pass `--text`
+alone. The pick can also be minted first (`bd create`) so the block cites an
+ID the next session can read back.
 
 `.beads[].verdict` is per candidate, and they are not interchangeable:
 
@@ -230,7 +236,7 @@ VERIFY_JSON=$(bash "$VERIFY_HELPER" --recommend solwend-abcd solwend-abcd mk-123
 |---|---|---|
 | `ok` | open | usable |
 | `warn` | `in_progress` / `blocked`, or in the lineage of the goals just closed | usable only if the goal is to FINISH or UNBLOCK it — and the block must say which, and name what it waits on. For lineage, see `--beat` below |
-| `disqualified` | `closed`, `deferred`, no such bead, or the `--recommend` pick continues the lineage without a `--beat` | **drop it.** Do not cite it, not even with a caveat |
+| `disqualified` | `closed`, `deferred`, no such bead, the `--recommend` pick continues the lineage without a `--beat`, or the pick is named in the OUT clause of the goal that just closed without an `--out-override` | **drop it.** Do not cite it, not even with a caveat |
 
 **Any candidate whose verb is build / create / add must assert the artifact's
 absence** with `--path`. A bead's status cannot catch this: an epic can be
@@ -255,6 +261,40 @@ consecutive goals (1b53da77, c60de386, c4cda02c) each recommended the next
 under one epic, and the fourth passed provenance, freshness, and shape before
 anything asked this. No `ic` on the host, or no goal store that answers, makes
 `.lineage.available` false and leaves the rest of the verdict standing.
+
+### The pick must not be what the last goal excluded: `--text` and `--out-of`
+
+A goal's `OUT:` clause is the user's decision about what this goal will not
+do. On 2026-09-04 the block that closed `jawnomicon ia-preview` recommended
+"export currency 646 to 694" — the second item of that goal's own OUT clause,
+excluded by the user in the text they had ratified. Nothing caught it: the pick
+was free text, so no bead was read back, and no check compared a
+recommendation against the exclusion list. The user asked "is that really the
+best next goal?" for the second time in the session.
+
+Run the verifier with `--text "<the /goal line>"` and `--out-of <where the
+just-closed goal's condition lives>`: a bead whose description carries the
+goal text (the epic, usually), a file, or the literal condition. `--out-of`
+repeats. When `ic goal list` answers, the most recently closed goal's
+`ConditionText` is read as a source automatically; on a host where goals are
+not minted into the store, `--out-of` is the only source, so pass it. A pick
+that names an item of any OUT clause is **disqualified**; the receipt's
+`.out_clause.matched` says which item and which source. If the exclusion has
+genuinely lapsed (the blocker landed, the user lifted the hold), pass
+`--out-override "<why>"`: the refusal becomes a warning, the reason is on the
+receipt, and the block must say it in prose — name the OUT item and why it is
+now in. Matching is by words, not exact phrase: "family and kind naming pass"
+matches "families v31 naming", and "export at canon 694" matches "export
+currency 646 to 694".
+
+### Worktrees read the main checkout's tracker
+
+Both helpers resolve a `.beads` found inside a linked git worktree (`git
+worktree add`, `bd worktree create`) to the main checkout. A worktree carries
+its own copy of the tracker that nothing syncs, so from inside one the beads a
+session created from the main checkout read as "no such bead" and `bd ready`
+is whatever was copied at creation — an empty result that is not a fact about
+the backlog. Two days of improvised blocks came from exactly that.
 
 ### Why this exists, and why provenance did not already cover it
 

--- a/commands/next-goal.md
+++ b/commands/next-goal.md
@@ -283,9 +283,11 @@ that names an item of any OUT clause is **disqualified**; the receipt's
 genuinely lapsed (the blocker landed, the user lifted the hold), pass
 `--out-override "<why>"`: the refusal becomes a warning, the reason is on the
 receipt, and the block must say it in prose — name the OUT item and why it is
-now in. Matching is by words, not exact phrase: "family and kind naming pass"
-matches "families v31 naming", and "export at canon 694" matches "export
-currency 646 to 694".
+now in. Matching is by words, not exact phrase: every word of the OUT item must
+appear in the pick, by shared prefix, and numbers ride free — "family and
+kind naming pass" matches "families v31 naming", and "export-currency at
+canon 694" matches "export currency 646 to 694". The pick's own OUT clause
+is not judged, since a successor restates what it inherits.
 
 ### Worktrees read the main checkout's tracker
 

--- a/hooks/lib-next-goal-provenance.sh
+++ b/hooks/lib-next-goal-provenance.sh
@@ -235,7 +235,7 @@ next_goal_verification_warning() {
             printf 'Next-goal verification: this turn emitted a Next-goal block, but scripts/next-goal-verify.sh never ran in this session, so no cited candidate was re-read at source. A bead that closed since you last saw it looks exactly like one that is still open. Re-run the shortlist through the verifier before standing behind the block.\n'
             ;;
         disqualified)
-            printf 'Next-goal verification: the verifier DISQUALIFIED %s, but a Next-goal block went out anyway. A closed, deferred, or nonexistent bead must not be proposed — and a path that already exists must not be proposed as something to build. Drop those candidates and re-derive.\n' \
+            printf 'Next-goal verification: the verifier DISQUALIFIED %s, but a Next-goal block went out anyway. A closed, deferred, or nonexistent bead must not be proposed; a path that already exists must not be proposed as something to build; and a pick named in the OUT clause of the goal that just closed reopens a decision the user made there. Drop those candidates and re-derive.\n' \
                 "${detail:-one or more candidates}"
             ;;
         unavailable)

--- a/scripts/next-goal-candidates.sh
+++ b/scripts/next-goal-candidates.sh
@@ -111,6 +111,29 @@ command -v jq >/dev/null 2>&1 || die_json '"jq not installed"'
 
 # ---------------------------------------------------------------- root discovery
 
+# A linked git worktree (git worktree add, bd worktree create) carries its own
+# .beads copy that nothing syncs: beads created from the main checkout read as
+# "no such bead" there, and its ready list is whatever was copied at creation.
+# Resolve a root found inside one to the checkout the tracker actually lives
+# in. Observed 2026-09-04: a session in a nested jawnomicon worktree saw zero
+# ready beads and improvised every Next-goal block for two days.
+tracker_home() {
+    local dir="$1" gitdir common main
+    command -v git >/dev/null 2>&1 || { printf '%s\n' "$dir"; return 0; }
+    gitdir="$(git -C "$dir" rev-parse --git-dir 2>/dev/null)" || { printf '%s\n' "$dir"; return 0; }
+    common="$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null)" || { printf '%s\n' "$dir"; return 0; }
+    [[ "$gitdir" = /* ]] || gitdir="$dir/$gitdir"
+    [[ "$common" = /* ]] || common="$dir/$common"
+    gitdir="$(cd "$gitdir" 2>/dev/null && pwd -P)"
+    common="$(cd "$common" 2>/dev/null && pwd -P)"
+    if [[ -n "$gitdir" && -n "$common" && "$gitdir" != "$common" ]]; then
+        main="$(dirname "$common")"
+        [[ -d "$main/.beads" ]] && { printf '%s\n' "$main"; return 0; }
+    fi
+    # Resolved, like the worktree branch above, so one tracker has one name.
+    printf '%s\n' "$(cd "$dir" 2>/dev/null && pwd -P || printf '%s' "$dir")"
+}
+
 discover_roots() {
     if [[ -n "${CLAVAIN_NEXT_GOAL_ROOTS:-}" ]]; then
         printf '%s\n' "${CLAVAIN_NEXT_GOAL_ROOTS}" | tr ':' '\n'
@@ -122,7 +145,7 @@ discover_roots() {
     # sees no tracker at all.
     local dir="$PWD" depth=0
     while [[ -n "$dir" && "$dir" != "/" && $depth -lt 12 ]]; do
-        [[ -d "$dir/.beads" ]] && printf '%s\n' "$dir"
+        [[ -d "$dir/.beads" ]] && tracker_home "$dir"
         dir="$(dirname "$dir")"
         depth=$((depth + 1))
     done

--- a/scripts/next-goal-verify.sh
+++ b/scripts/next-goal-verify.sh
@@ -51,17 +51,45 @@
 # or no store that answers, makes lineage UNAVAILABLE and says so; the rest of
 # the verdict stands.
 #
+# OUT CLAUSE — why a live, open, out-of-lineage pick can still be the wrong
+# recommendation.
+#
+# On 2026-09-04 the goal jawnomicon ia-preview closed with the clause
+# "OUT: index density, export currency 646 to 694, families v31 naming, ...".
+# The Next-goal block that closed it recommended "export currency 646 to 694".
+# The exclusion was the user's decision, made in the goal they had just
+# ratified, and the block silently reopened it three minutes after it landed.
+# Nothing above can see this: the pick was free text (no bead to read back),
+# and no check compares a recommendation against what the last goal excluded.
+#
+# --text carries the /goal text the block is about to emit; --out-of names
+# where the just-closed goal's condition lives (a bead whose description holds
+# it, a file, or the literal text) and may repeat. When the goal store answers,
+# the most recently closed goal's ConditionText is read automatically as well.
+# A recommendation that matches an item of any OUT clause is DISQUALIFIED —
+# unless --out-override gives the reason it is now in, which downgrades the
+# refusal to a warning and puts the reason on the receipt. The block must make
+# that case in prose too.
+#
+# WORKTREES — a linked git worktree (git worktree add, bd worktree create)
+# carries its own .beads copy that nothing syncs, so beads created from the
+# main checkout read as "no such bead" there. Roots found inside a linked
+# worktree resolve to the checkout the tracker actually lives in.
+#
 # Usage:
-#   next-goal-verify.sh [--recommend <id>] [--beat <id>] <bead-id> [<bead-id>...]
+#   next-goal-verify.sh [--recommend <id>] [--beat <id>] [--text <goal text>]
+#                       [--out-of <bead|file|text>]... [--out-override <reason>]
+#                       <bead-id> [<bead-id>...]
 #   next-goal-verify.sh --path apps/web/components/x/ <bead-id>     # see --path
 #   next-goal-verify.sh --recommend mk-12 --beat mk-40 mk-12 mk-40  # see LINEAGE
+#   next-goal-verify.sh --recommend mk-12 --text "/goal ..." --out-of mk-9 mk-12  # see OUT CLAUSE
 #
 # Exit: 0 = every candidate usable (or verification unavailable — fail-open),
 #       3 = at least one candidate DISQUALIFIED. Always prints one JSON object.
 
 set -uo pipefail
 
-SCHEMA_VERSION="clavain.next-goal-verify/v2"
+SCHEMA_VERSION="clavain.next-goal-verify/v3"
 MAX_ROOTS="${CLAVAIN_NEXT_GOAL_MAX_ROOTS:-6}"
 BD_TIMEOUT="${CLAVAIN_NEXT_GOAL_BD_TIMEOUT:-20}"
 
@@ -72,6 +100,9 @@ IDS=()
 PATHS=()
 RECOMMEND=""
 BEAT=""
+TEXT=""
+OUT_OF=()
+OUT_OVERRIDE=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --path) PATHS+=("${2:-}"); shift 2 || shift ;;
@@ -80,6 +111,12 @@ while [[ $# -gt 0 ]]; do
         --recommend=*) RECOMMEND="${1#--recommend=}"; shift ;;
         --beat) BEAT="${2:-}"; shift 2 || shift ;;
         --beat=*) BEAT="${1#--beat=}"; shift ;;
+        --text) TEXT="${2:-}"; shift 2 || shift ;;
+        --text=*) TEXT="${1#--text=}"; shift ;;
+        --out-of) OUT_OF+=("${2:-}"); shift 2 || shift ;;
+        --out-of=*) OUT_OF+=("${1#--out-of=}"); shift ;;
+        --out-override) OUT_OVERRIDE="${2:-}"; shift 2 || shift ;;
+        --out-override=*) OUT_OVERRIDE="${1#--out-override=}"; shift ;;
         -h|--help) sed -n '2,60p' "$0"; exit 0 ;;
         *) IDS+=("$1"); shift ;;
     esac
@@ -128,7 +165,7 @@ unavailable() {
 }
 
 command -v jq >/dev/null 2>&1 || unavailable "jq not installed"
-[[ ${#IDS[@]} -gt 0 || ${#PATHS[@]} -gt 0 ]] || unavailable "nothing to verify"
+[[ ${#IDS[@]} -gt 0 || ${#PATHS[@]} -gt 0 || -n "$TEXT" ]] || unavailable "nothing to verify"
 
 # bd is required only for BEAD IDs. A --path run asks the filesystem whether an
 # artifact exists and never touches a tracker, so demanding bd for it made the
@@ -146,6 +183,26 @@ fi
 # then add the workspace tracker, which is not an ancestor of every checkout.
 # Two different resolution schemes for the same ID space would be a way for the
 # gate to disagree with the thing it is gating.
+# A linked git worktree carries its own .beads copy that nothing syncs. Resolve
+# a root found inside one to the checkout the tracker actually lives in, so
+# the beads the session created from the main checkout can be read back.
+tracker_home() {
+    local dir="$1" gitdir common main
+    command -v git >/dev/null 2>&1 || { printf '%s\n' "$dir"; return 0; }
+    gitdir="$(git -C "$dir" rev-parse --git-dir 2>/dev/null)" || { printf '%s\n' "$dir"; return 0; }
+    common="$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null)" || { printf '%s\n' "$dir"; return 0; }
+    [[ "$gitdir" = /* ]] || gitdir="$dir/$gitdir"
+    [[ "$common" = /* ]] || common="$dir/$common"
+    gitdir="$(cd "$gitdir" 2>/dev/null && pwd -P)"
+    common="$(cd "$common" 2>/dev/null && pwd -P)"
+    if [[ -n "$gitdir" && -n "$common" && "$gitdir" != "$common" ]]; then
+        main="$(dirname "$common")"
+        [[ -d "$main/.beads" ]] && { printf '%s\n' "$main"; return 0; }
+    fi
+    # Resolved, like the worktree branch above, so one tracker has one name.
+    printf '%s\n' "$(cd "$dir" 2>/dev/null && pwd -P || printf '%s' "$dir")"
+}
+
 discover_roots() {
     if [[ -n "${CLAVAIN_NEXT_GOAL_ROOTS:-}" ]]; then
         printf '%s\n' "${CLAVAIN_NEXT_GOAL_ROOTS}" | tr ':' '\n'
@@ -153,7 +210,7 @@ discover_roots() {
     fi
     local dir="$PWD" depth=0
     while [[ -n "$dir" && "$dir" != "/" && $depth -lt 12 ]]; do
-        [[ -d "$dir/.beads" ]] && printf '%s\n' "$dir"
+        [[ -d "$dir/.beads" ]] && tracker_home "$dir"
         dir="$(dirname "$dir")"
         depth=$((depth + 1))
     done
@@ -256,6 +313,8 @@ fi
 LINEAGE_WINDOW="${CLAVAIN_NEXT_GOAL_LINEAGE_WINDOW:-4}"
 LINEAGE_MIN="${CLAVAIN_NEXT_GOAL_LINEAGE_MIN:-2}"
 LINEAGE_JSON='{"available":false,"reason":"no bead candidates, so there is no recommendation to place","window":[],"streak":[]}'
+LAST_GOAL_ID=""
+LAST_GOAL_CONDITION=""
 RUN_DISQ=""
 ROOT_EPIC=""
 declare -A ROOT_MEMO
@@ -326,12 +385,15 @@ if [[ ${#IDS[@]} -gt 0 ]]; then
             GOALS_SEEN=1
             GOALS_ALL="$(jq -c --arg root "$root" --argjson g "$raw" \
                 '. + [$g[] | select(.Status == "closed")
-                      | {id: .ID, closed_at: (.ClosedAt // 0), bead_id: (.BeadID // null), _root: $root}]' <<<"$GOALS_ALL")"
+                      | {id: .ID, closed_at: (.ClosedAt // 0), bead_id: (.BeadID // null), _root: $root,
+                         condition: (.ConditionText // "")}]' <<<"$GOALS_ALL")"
         done
         if [[ $GOALS_SEEN -eq 0 ]]; then
             LINEAGE_JSON='{"available":false,"reason":"no goal store answered in any reachable root, so the lineage of the last closed goals cannot be read","window":[],"streak":[]}'
         else
             WINDOW_JSON="$(jq -c --argjson w "$LINEAGE_WINDOW" 'sort_by(-(.closed_at)) | .[0:$w]' <<<"$GOALS_ALL")"
+            LAST_GOAL_ID="$(jq -r '.[0].id // empty' <<<"$WINDOW_JSON")"
+            LAST_GOAL_CONDITION="$(jq -r '.[0].condition // empty' <<<"$WINDOW_JSON")"
 
             # Each goal's lineage: root epics of its own bead and of every bead
             # labeled with it. Empty means UNKNOWN, and unknown never counts.
@@ -438,6 +500,97 @@ fi
 # have been open and the components still present. So a candidate whose verb is
 # "create"/"build"/"add" has to assert the artifact's absence, and asserting is
 # a command, not a belief.
+# ---------------------------------------------------------------- OUT clause
+
+# Every source the just-closed goal's condition can come from, in the order
+# the user gave them, then the goal store's most recently closed goal.
+OUT_SOURCES="[]"
+for src in ${OUT_OF[@]+"${OUT_OF[@]}"}; do
+    [[ -z "$src" ]] && continue
+    label="text"; body="$src"
+    if [[ "$src" =~ ^[A-Za-z][A-Za-z0-9]*-[A-Za-z0-9.]+$ ]] && command -v bd >/dev/null 2>&1; then
+        for root in ${ROOTS[@]+"${ROOTS[@]}"}; do
+            raw="$(bd_show "$root" "$src")"
+            if jq -e 'type == "array" and length > 0' >/dev/null 2>&1 <<<"$raw"; then
+                label="bead $src"; body="$(jq -r '.[0].description // ""' <<<"$raw")"; break
+            fi
+        done
+    fi
+    if [[ "$label" == "text" && -f "$src" ]]; then
+        label="file $src"; body="$(cat "$src" 2>/dev/null)"
+    fi
+    OUT_SOURCES="$(jq -c --arg l "$label" --arg b "$body" '. + [{source: $l, text: $b}]' <<<"$OUT_SOURCES")"
+done
+if [[ -n "$LAST_GOAL_ID" && -n "$LAST_GOAL_CONDITION" ]]; then
+    OUT_SOURCES="$(jq -c --arg l "goal $LAST_GOAL_ID" --arg b "$LAST_GOAL_CONDITION" '. + [{source: $l, text: $b}]' <<<"$OUT_SOURCES")"
+fi
+
+# The recommendation as the reader will see it: the /goal text plus the
+# recommended bead's title. Not its description — a bead filed as a follow-up
+# often explains that it is OUT of the goal that spawned it, and would match.
+REC_TITLE=""
+if [[ -n "$RECOMMEND" ]]; then
+    REC_TITLE="$(jq -r --arg id "$RECOMMEND" 'first(.[] | select(.id == $id)) | .title // ""' <<<"$BEADS_JSON")"
+fi
+
+OUT_JSON="$(jq -cn \
+    --argjson sources "$OUT_SOURCES" --arg text "$TEXT" --arg title "$REC_TITLE" \
+    --arg rec "$RECOMMEND" --arg override "$OUT_OVERRIDE" '
+    def norm: ascii_downcase | gsub("[^a-z0-9]+"; " ") | gsub("^ +| +$"; "");
+    def stop: ["any","the","a","an","to","of","or","and","in","on","for","with","by","from",
+               "its","it","this","that","not","no","all","as","at","is","are","be","into","up"];
+    def toks: norm | split(" ") | map(select(length > 0)) | map(select(. as $t | stop | index($t) | not));
+    # Words gate the match; numbers and version tags ride along free, so
+    # "export currency 646 to 694" still names "export currency at 694".
+    def words: toks | map(select(test("[0-9]") | not));
+    # Shared-prefix similarity: families/family, harvest/harvesting match;
+    # currency/current does not.
+    def cp($a; $b): [range(0; ([($a | length), ($b | length)] | min))] | map(select($a[:. + 1] == $b[:. + 1])) | length;
+    def sim($a; $b): ($a == $b) or (cp($a; $b) as $c | $c >= 4 and $c >= (([($a | length), ($b | length)] | min) - 2));
+    # The clause after the first "OUT:" up to the end of that paragraph.
+    # jq splits "" into [], so the no-clause path must not index null.
+    def clause: (split("OUT:") | if length > 1 then .[1:] | join("OUT:") else "" end) | (split("\n\n")[0] // "");
+    def items: clause | split(",") | map(split(";")[]) | map(gsub("^\\s+|\\s+$"; ""))
+               | map(select(length > 0))
+               | map({item: ., words: words})
+               | map(select((.words | length) >= 2 or ((.words | length) == 1 and (.words[0] | length) >= 6)));
+    (($text + " " + $title) | toks) as $cand
+    | [$sources[] | . as $s | (.text | items)[] | . + {source: $s.source}] as $all
+    | [$all[] | select(all(.words[]; . as $w | any($cand[]; sim(.; $w))))] as $hits
+    | (if $rec != "" then $rec elif $text != "" then "<text>" else null end) as $subject
+    | if ($sources | length) == 0 then
+        {available: false, reason: "no OUT source: pass --out-of <bead|file|text>, or no goal store answered", subject: $subject,
+         sources: [], items: 0, matched: [], verdict: null}
+      elif ($all | length) == 0 then
+        {available: true, reason: ("no OUT clause found in " + ([$sources[].source] | join(", "))), subject: $subject,
+         sources: [$sources[].source], items: 0, matched: [], verdict: "ok"}
+      elif $cand == [] then
+        {available: false, reason: "nothing to judge: pass --text with the /goal text and/or --recommend <bead>", subject: $subject,
+         sources: [$sources[].source], items: ($all | length), matched: [], verdict: null}
+      elif ($hits | length) == 0 then
+        {available: true, reason: ("outside the OUT clause of " + ([$sources[].source] | unique | join(", "))), subject: $subject,
+         sources: [$sources[].source], items: ($all | length), matched: [], verdict: "ok"}
+      elif $override != "" then
+        {available: true, verdict: "warn", subject: $subject,
+         sources: [$sources[].source], items: ($all | length), matched: [$hits[] | {item, source}], override: $override,
+         reason: ("named in the OUT clause of " + ($hits[0].source) + " (\"" + $hits[0].item + "\"); allowed on record because: " + $override)}
+      else
+        {available: true, verdict: "disqualified", subject: $subject,
+         sources: [$sources[].source], items: ($all | length), matched: [$hits[] | {item, source}],
+         reason: ("named in the OUT clause of " + ($hits[0].source) + " (\"" + $hits[0].item + "\") — the user excluded it there; re-proposing it reopens that decision. Say why it is now in with --out-override, or recommend something else")}
+      end')"
+
+if [[ "$(jq -r '.verdict // empty' <<<"$OUT_JSON")" == "disqualified" ]]; then
+    OUT_REASON="$(jq -r '.reason' <<<"$OUT_JSON")"
+    if [[ -n "$RECOMMEND" ]]; then
+        BEADS_JSON="$(jq -c --arg id "$RECOMMEND" --arg r "$OUT_REASON" \
+            'map(if .id == $id then . + {verdict: "disqualified", reason: $r} else . end)' <<<"$BEADS_JSON")"
+    fi
+    OUT_DISQ="$(jq -r '(.subject // "<text>") + " (" + (.matched[0].source) + " OUT: \"" + (.matched[0].item) + "\")"' <<<"$OUT_JSON")"
+else
+    OUT_DISQ=""
+fi
+
 for p in ${PATHS[@]+"${PATHS[@]}"}; do
     if [[ -e "$p" ]]; then
         detail="exists"
@@ -454,10 +607,11 @@ for p in ${PATHS[@]+"${PATHS[@]}"}; do
 done
 PATHS_JSON="${PATHS_JSON:-[]}"
 
-DISQUALIFIED="$(jq -cn --argjson b "$BEADS_JSON" --argjson p "$PATHS_JSON" --arg run "$RUN_DISQ" \
+DISQUALIFIED="$(jq -cn --argjson b "$BEADS_JSON" --argjson p "$PATHS_JSON" --arg run "$RUN_DISQ" --arg out "$OUT_DISQ" \
     '[($b[] | select(.verdict == "disqualified") | .id),
       ($p[] | select(.verdict == "disqualified") | .path)]
-     + (if $run == "" then [] else [$run] end)')"
+     + (if $run == "" then [] else [$run] end)
+     + (if $out == "" then [] else [$out] end) | unique')"
 
 # `ok: (($disq | length) == 0)` — the OUTER parentheses are load-bearing. jq 1.7
 # (Debian, and the CI runner) rejects `key: a == b` inside an object literal
@@ -476,11 +630,14 @@ PAYLOAD="$(jq -cn \
     --argjson paths "$PATHS_JSON" \
     --argjson disq "$DISQUALIFIED" \
     --argjson lineage "$LINEAGE_JSON" \
+    --argjson out "$OUT_JSON" \
     '{schema_version: $schema, available: true, verified_at: $stamp,
       roots_discovered: ($roots_seen == 1),
       beads: $beads, paths: $paths, disqualified: $disq,
-      warnings: [$beads[] | select(.verdict == "warn") | .id],
+      warnings: ([$beads[] | select(.verdict == "warn") | .id]
+                 + (if $out.verdict == "warn" then [($out.subject // "<text>")] else [] end)),
       lineage: $lineage,
+      out_clause: $out,
       ok: (($disq | length) == 0)}')"
 
 if [[ "$(jq -r '.ok' <<<"$PAYLOAD")" == "true" ]]; then

--- a/scripts/next-goal-verify.sh
+++ b/scripts/next-goal-verify.sh
@@ -386,14 +386,25 @@ if [[ ${#IDS[@]} -gt 0 ]]; then
             GOALS_ALL="$(jq -c --arg root "$root" --argjson g "$raw" \
                 '. + [$g[] | select(.Status == "closed")
                       | {id: .ID, closed_at: (.ClosedAt // 0), bead_id: (.BeadID // null), _root: $root,
-                         condition: (.ConditionText // "")}]' <<<"$GOALS_ALL")"
+                         condition: (.ConditionText // ""), project: (.ProjectDir // "")}]' <<<"$GOALS_ALL")"
         done
         if [[ $GOALS_SEEN -eq 0 ]]; then
             LINEAGE_JSON='{"available":false,"reason":"no goal store answered in any reachable root, so the lineage of the last closed goals cannot be read","window":[],"streak":[]}'
         else
             WINDOW_JSON="$(jq -c --argjson w "$LINEAGE_WINDOW" 'sort_by(-(.closed_at)) | .[0:$w]' <<<"$GOALS_ALL")"
-            LAST_GOAL_ID="$(jq -r '.[0].id // empty' <<<"$WINDOW_JSON")"
-            LAST_GOAL_CONDITION="$(jq -r '.[0].condition // empty' <<<"$WINDOW_JSON")"
+            # The automatic OUT source is THIS project's last closed goal. The
+            # store is shared across projects and the lineage window merges
+            # them on purpose; an OUT clause does not transfer that way — on
+            # 2026-09-04 a jawnomicon pick was judged against elf-revel's.
+            # "This project" is the nearest root; ProjectDir may be absolute,
+            # a subdirectory (a worktree), or just the project's name.
+            LAST_PROJECT_GOAL="$(jq -c --arg here "${ROOTS[0]:-}" '
+                [.[] | .project as $p
+                     | select($p != "" and $here != "" and
+                              ($p == $here or ($here | endswith("/" + $p)) or ($p | startswith($here + "/"))))]
+                | sort_by(-(.closed_at)) | .[0] // {}' <<<"$GOALS_ALL")"
+            LAST_GOAL_ID="$(jq -r '.id // empty' <<<"$LAST_PROJECT_GOAL")"
+            LAST_GOAL_CONDITION="$(jq -r '.condition // empty' <<<"$LAST_PROJECT_GOAL")"
 
             # Each goal's lineage: root epics of its own bead and of every bead
             # labeled with it. Empty means UNKNOWN, and unknown never counts.
@@ -540,8 +551,9 @@ OUT_JSON="$(jq -cn \
     def stop: ["any","the","a","an","to","of","or","and","in","on","for","with","by","from",
                "its","it","this","that","not","no","all","as","at","is","are","be","into","up"];
     def toks: norm | split(" ") | map(select(length > 0)) | map(select(. as $t | stop | index($t) | not));
-    # Words gate the match; numbers and version tags ride along free, so
-    # "export currency 646 to 694" still names "export currency at 694".
+    # Every word of the item must appear in the pick; numbers and version
+    # tags ride along free, so "export currency 646 to 694" still names
+    # "export-currency at canon 694".
     def words: toks | map(select(test("[0-9]") | not));
     # Shared-prefix similarity: families/family, harvest/harvesting match;
     # currency/current does not.
@@ -554,7 +566,10 @@ OUT_JSON="$(jq -cn \
                | map(select(length > 0))
                | map({item: ., words: words})
                | map(select((.words | length) >= 2 or ((.words | length) == 1 and (.words[0] | length) >= 6)));
-    (($text + " " + $title) | toks) as $cand
+    # The pick is judged on what it proposes to DO. Its own OUT clause usually
+    # restates the exclusions it inherits, and must not match them.
+    def own: split("OUT:")[0];
+    ((($text | own) + " " + $title) | toks) as $cand
     | [$sources[] | . as $s | (.text | items)[] | . + {source: $s.source}] as $all
     | [$all[] | select(all(.words[]; . as $w | any($cand[]; sim(.; $w))))] as $hits
     | (if $rec != "" then $rec elif $text != "" then "<text>" else null end) as $subject

--- a/tests/shell/next_goal_candidates.bats
+++ b/tests/shell/next_goal_candidates.bats
@@ -327,3 +327,44 @@ make_backlog_root() {
     run_helper "$root"
     [ "$(jq -r '.roadmap.status' <<<"$output")" = "stale" ]
 }
+
+# ------------------------------------------------------------------- worktrees
+#
+# A linked git worktree (git worktree add, bd worktree create) carries its own
+# .beads copy that nothing syncs. From inside one, the main checkout's beads
+# are "no such bead" and its ready list is whatever was copied at creation.
+# Observed 2026-09-04: two days of improvised blocks from a nested worktree.
+
+@test "worktree: a .beads inside a linked worktree resolves to the main checkout, once" {
+    command -v git >/dev/null || skip "git not installed"
+    local main
+    main="$(make_root main '[{"id":"m-1","title":"from main","status":"open","priority":1}]')"
+    git -C "$TEST_DIR" init -q main
+    git -C "$main" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+    git -C "$main" worktree add -q "$main/wt" -b wt
+    mkdir -p "$main/wt/.beads"
+    printf '[]' > "$main/wt/.beads/ready.json"
+    printf '%s' "$main/wt/.beads/stale-copy" > "$main/wt/.beads/dbpath"
+    unset CLAVAIN_NEXT_GOAL_ROOTS
+    pushd "$main/wt" >/dev/null
+    HOME="$TEST_DIR" run --separate-stderr bash "$SCRIPT_UNDER_TEST"
+    popd >/dev/null
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.roots | length' <<<"$output")" -eq 1 ]
+    [ "$(jq -r '.roots[0].root' <<<"$output")" = "$(cd "$main" && pwd -P)" ]
+    [ "$(jq -r '.candidates | length' <<<"$output")" -eq 1 ]
+    [ "$(jq -r '.candidates[0].id' <<<"$output")" = "m-1" ]
+}
+
+@test "worktree: the main checkout itself is unaffected" {
+    command -v git >/dev/null || skip "git not installed"
+    local main
+    main="$(make_root main '[{"id":"m-1","title":"from main","status":"open","priority":1}]')"
+    git -C "$TEST_DIR" init -q main
+    unset CLAVAIN_NEXT_GOAL_ROOTS
+    pushd "$main" >/dev/null
+    HOME="$TEST_DIR" run --separate-stderr bash "$SCRIPT_UNDER_TEST"
+    popd >/dev/null
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.roots[0].root' <<<"$output")" = "$(cd "$main" && pwd -P)" ]
+}

--- a/tests/shell/next_goal_verify.bats
+++ b/tests/shell/next_goal_verify.bats
@@ -424,3 +424,51 @@ OUT_TEXT='OUTCOME: a site. GATE 1 (mk): words. DONE WHEN: green. OUT: index dens
     [ "$status" -eq 0 ]
     [ "$(jq -r '.beads[0].root' <<<"$output")" = "$(cd "$main" && pwd -P)" ]
 }
+
+@test "out-clause: the pick's own OUT clause is not judged against the last goal's" {
+    # A successor goal normally restates what it inherits as excluded. Only
+    # what the pick proposes to DO is compared.
+    run bash "$SCRIPT" --text "constellation-nav — OUTCOME: nearest figures on every page. OUT: export currency, naming, any edit to data or vocab." --out-of "$OUT_TEXT"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.out_clause.verdict' <<<"$output")" = "ok" ]
+}
+
+@test "out-clause: the automatic source is this project's last closed goal, not another project's" {
+    make_bd_stub "$(bead_json open)"
+    cat > "$STUB_DIR/ic" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1 \$2" == "goal list" ]]; then cat <<'JSON'
+[{"ID":"g-else","Status":"closed","ClosedAt":900,"BeadID":null,"ProjectDir":"/elsewhere/other","ConditionText":"OUTCOME: other. OUT: nearest figures."},
+ {"ID":"g-here","Status":"closed","ClosedAt":100,"BeadID":null,"ProjectDir":"$WORK_DIR","ConditionText":"OUTCOME: here. OUT: export currency 646 to 694."},
+ {"ID":"g-open","Status":"open","ClosedAt":0,"BeadID":null,"ProjectDir":"$WORK_DIR","ConditionText":"OUT: everything."}]
+JSON
+exit 0
+fi
+exit 0
+EOF
+    chmod +x "$STUB_DIR/ic"
+    run bash "$SCRIPT" --recommend x-1 --text "nearest figures on every page" x-1
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.out_clause.sources | join(",")' <<<"$output")" = "goal g-here" ]
+    [ "$(jq -r '.out_clause.verdict' <<<"$output")" = "ok" ]
+    run bash "$SCRIPT" --recommend x-1 --text "export currency at canon 694" x-1
+    [ "$status" -eq 3 ]
+    [ "$(jq -r '.out_clause.matched[0].source' <<<"$output")" = "goal g-here" ]
+}
+
+@test "out-clause: a project name as ProjectDir still scopes to this project" {
+    make_bd_stub "$(bead_json open)"
+    local name; name="$(basename "$WORK_DIR")"
+    cat > "$STUB_DIR/ic" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1 \$2" == "goal list" ]]; then
+  printf '[{"ID":"g-name","Status":"closed","ClosedAt":5,"BeadID":null,"ProjectDir":"%s","ConditionText":"OUT: any harvest."}]\n' "$name"
+  exit 0
+fi
+exit 0
+EOF
+    chmod +x "$STUB_DIR/ic"
+    run bash "$SCRIPT" --recommend x-1 --text "harvest the next eight volumes" x-1
+    [ "$status" -eq 3 ]
+    [ "$(jq -r '.out_clause.matched[0].source' <<<"$output")" = "goal g-name" ]
+}

--- a/tests/shell/next_goal_verify.bats
+++ b/tests/shell/next_goal_verify.bats
@@ -202,7 +202,7 @@ EOF
     make_bd_stub "$(bead_json closed)"
     run bash "$SCRIPT" x-1
     [ -f "$RECEIPTS/test-session.json" ]
-    [ "$(jq -r '.schema_version' "$RECEIPTS/test-session.json")" = "clavain.next-goal-verify/v2" ]
+    [ "$(jq -r '.schema_version' "$RECEIPTS/test-session.json")" = "clavain.next-goal-verify/v3" ]
     [ "$(jq -r '.ok' "$RECEIPTS/test-session.json")" = "false" ]
 }
 
@@ -324,5 +324,103 @@ EOF
     [ "$status" -eq 0 ]
     [ "$(jq -r '.ok' <<<"$output")" = "true" ]
     [ "$(jq -r '.lineage.available' <<<"$output")" = "false" ]
-    [ "$(jq -r '.schema_version' <<<"$output")" = "clavain.next-goal-verify/v2" ]
+    [ "$(jq -r '.schema_version' <<<"$output")" = "clavain.next-goal-verify/v3" ]
+}
+
+# ------------------------------------------------------------------ OUT clause
+#
+# 2026-09-04: the block that closed `jawnomicon ia-preview` recommended
+# "export currency 646 to 694", the second item of that goal's own OUT clause.
+# The pick was free text, so no bead was read back, and nothing compared a
+# recommendation against what the user had just excluded.
+
+OUT_TEXT='OUTCOME: a site. GATE 1 (mk): words. DONE WHEN: green. OUT: index density, export currency 646 to 694, families v31 naming, any edit to data, vocab, or committed batch records, any harvest.'
+
+@test "out-clause: a free-text pick named in the OUT clause is disqualified" {
+    run bash "$SCRIPT" --text "jawnomicon export-currency — OUTCOME: the site builds from an export at canon 694" --out-of "$OUT_TEXT"
+    [ "$status" -eq 3 ]
+    [ "$(jq -r '.ok' <<<"$output")" = "false" ]
+    [ "$(jq -r '.out_clause.verdict' <<<"$output")" = "disqualified" ]
+    [ "$(jq -r '.out_clause.matched[0].item' <<<"$output")" = "export currency 646 to 694" ]
+    [ "$(jq -r '.out_clause.matched[0].source' <<<"$output")" = "text" ]
+    [ "$(jq -r '.disqualified | length' <<<"$output")" -eq 1 ]
+}
+
+@test "out-clause: words gate the match, numbers and word forms do not" {
+    # "families v31 naming" vs "family ... naming": families/family share a
+    # prefix, v31 is a tag and rides free.
+    run bash "$SCRIPT" --text "Family and kind naming pass — 44 family names and 19 cluster labels" --out-of "$OUT_TEXT"
+    [ "$status" -eq 3 ]
+    [ "$(jq -r '.out_clause.matched[0].item' <<<"$output")" = "families v31 naming" ]
+}
+
+@test "out-clause: a pick outside the OUT clause passes" {
+    run bash "$SCRIPT" --text "constellation-nav — every figure page leads to its nearest figures" --out-of "$OUT_TEXT"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.ok' <<<"$output")" = "true" ]
+    [ "$(jq -r '.out_clause.verdict' <<<"$output")" = "ok" ]
+    [ "$(jq -r '.out_clause.items' <<<"$output")" -ge 3 ]
+}
+
+@test "out-clause: --out-override downgrades the refusal to a warning and records the reason" {
+    run bash "$SCRIPT" --text "export currency 646 to 694" --out-of "$OUT_TEXT" --out-override "xjq landed and the hold was lifted"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.ok' <<<"$output")" = "true" ]
+    [ "$(jq -r '.out_clause.verdict' <<<"$output")" = "warn" ]
+    [ "$(jq -r '.out_clause.override' <<<"$output")" = "xjq landed and the hold was lifted" ]
+    [ "$(jq -r '.warnings | index("<text>")' <<<"$output")" != "null" ]
+}
+
+@test "out-clause: the clause is read from a bead's description and the recommended bead is disqualified" {
+    make_bd_stub "$(bead_json open ',"description":"jawnomicon ia-preview — OUTCOME: a site. OUT: index density, export currency 646 to 694, any harvest.\n\nFinding at intake: unrelated prose that mentions harvest twice."')"
+    run bash "$SCRIPT" --recommend x-1 --text "/goal x-1 — export currency: bring the site to canon 694" --out-of x-9 x-1
+    [ "$status" -eq 3 ]
+    [ "$(jq -r '.out_clause.matched[0].source' <<<"$output")" = "bead x-9" ]
+    [ "$(jq -r '.out_clause.subject' <<<"$output")" = "x-1" ]
+    [ "$(jq -r '.beads[0].verdict' <<<"$output")" = "disqualified" ]
+    [ "$(jq -r '.beads[0].reason' <<<"$output")" != "open" ]
+    [ "$(jq -r '.out_clause.items' <<<"$output")" -eq 3 ]
+}
+
+@test "out-clause: prose after the OUT paragraph is not part of the clause" {
+    # "harvest" appears in the intake paragraph below the clause; only the
+    # clause's own items count, and "harvest" is one of them here — so a pick
+    # about harvest is caught, but a pick about "intake" is not.
+    make_bd_stub "$(bead_json open ',"description":"OUT: any harvest.\n\nFinding at intake: the intake pass found nothing."')"
+    run bash "$SCRIPT" --text "intake pass: rerun the intake" --out-of x-9
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.out_clause.verdict' <<<"$output")" = "ok" ]
+}
+
+@test "out-clause: no source at all is reported as not evaluated, not as a pass" {
+    run bash "$SCRIPT" --text "anything"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.out_clause.available' <<<"$output")" = "false" ]
+    [ "$(jq -r '.out_clause.verdict' <<<"$output")" = "null" ]
+}
+
+@test "out-clause: a source with no OUT clause passes and says so" {
+    run bash "$SCRIPT" --text "anything" --out-of "OUTCOME: a goal with no exclusions."
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.out_clause.verdict' <<<"$output")" = "ok" ]
+    [[ "$(jq -r '.out_clause.reason' <<<"$output")" == "no OUT clause found in"* ]]
+}
+
+# ------------------------------------------------------------------- worktrees
+
+@test "worktree: a root inside a linked git worktree resolves to the main checkout" {
+    command -v git >/dev/null || skip "git not installed"
+    local main="$WORK_DIR/main"
+    mkdir -p "$main/.beads"
+    git -C "$WORK_DIR" init -q main
+    git -C "$main" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+    git -C "$main" worktree add -q "$main/wt" -b wt
+    mkdir -p "$main/wt/.beads"
+    make_bd_stub "$(bead_json open)"
+    unset CLAVAIN_NEXT_GOAL_ROOTS
+    pushd "$main/wt" >/dev/null
+    HOME="$WORK_DIR" run bash "$SCRIPT" x-1
+    popd >/dev/null
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.beads[0].root' <<<"$output")" = "$(cd "$main" && pwd -P)" ]
 }


### PR DESCRIPTION
## Why

On 2026-09-04 the Next-goal block that closed `jawnomicon ia-preview` recommended "export currency 646 to 694" — the second item of that goal's own `OUT:` clause, excluded by the user in the text they had ratified minutes earlier. The pick was free text, so the verifier never saw it, and no check compares a recommendation against what the last goal excluded. mk: "is that really the best next goal?", then "i thought we have fixed this multiple ways".

The earlier fixes (provenance receipt, verify-at-source, lineage) are real and were installed, but the session had also been running from a nested `bd worktree create` checkout whose own `.beads` copy answered `bd ready` with nothing, so the helpers were never consulted and the block was written from memory 40 times.

## What

- `scripts/next-goal-verify.sh`: `--text`, `--out-of` (repeatable), `--out-override`; automatic OUT source from the goal store's last closed `ConditionText`; word-level matching with shared-prefix similarity; `.out_clause` on the receipt; schema v3.
- Both helpers: `tracker_home` resolves a linked worktree to its main checkout.
- `commands/next-goal.md`: Step 3 requires `--text`/`--out-of`; two new subsections.
- `hooks/lib-next-goal-provenance.sh`: the DISQUALIFIED message names the OUT case.
- Tests: 11 new bats cases (`next_goal_verify.bats`, `next_goal_candidates.bats`); 74/74.

## Not fixed here

The Stop hook that would have flagged the improvised blocks never ran in that session: Claude Code refuses hooks whose plugin dir was deleted by a later plugin update (`Plugin directory does not exist: .../clavain/0.6.294`). Same family as mk-i3u8. That needs a stable hook path outside the versioned cache, or no plugin updates under long-lived sessions. Tracked on mk-lp3h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## CI

`Plugin Tests` is red on `main` at 57d80c6 with the same ten failures this branch shows (`routing_mode.bats` calls `md5`, which Linux lacks; the Dolt push gate, calibration close gate and Codex installer suites). All next-goal suites pass in CI and locally (77/77). Second commit abdf8be: the pick is judged without its own OUT clause, and the automatic source is scoped to this project's goals — both found by running the verifier on the real recommendation.
